### PR TITLE
Use Linewise User Interface for Slack rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ emacs client for Slack
 - [websocket](https://github.com/ahyatt/emacs-websocket)
 - oauth2
   - do `package install`
+- [circe](https://github.com/jorgenschaefer/circe) (for the Linewise
+  User Interface library).
 
 
 ## configure
@@ -18,6 +20,7 @@ emacs client for Slack
 
 (el-get-bundle websocket)
 (el-get-bundle oauth2)
+(el-get-bundle circe)
 (use-package slack
   :commands (slack-start)
   :init

--- a/slack-buffer.el
+++ b/slack-buffer.el
@@ -35,17 +35,23 @@
 (defvar slack-current-room)
 (make-local-variable 'slack-current-room)
 
+(defun slack-get-buffer-create (buf-name)
+  (let ((buffer (get-buffer buf-name)))
+    (unless buffer
+      (setq buffer (generate-new-buffer buf-name))
+      (with-current-buffer buffer
+        (slack-mode)))
+    buffer))
+
 (defun slack-buffer-set-current-room (room)
   (set (make-local-variable 'slack-current-room) room))
 
 (defun slack-buffer-create (buf-name room header messages)
-  (let ((buffer (get-buffer-create buf-name)))
-    (if buffer
-        (with-current-buffer buffer
-          (slack-mode)
-          (mapc (lambda (m) (lui-insert m t)) (reverse messages))
-          (slack-buffer-set-current-room room)
-          (goto-char (point-max))))
+  (let ((buffer (slack-get-buffer-create buf-name)))
+    (with-current-buffer buffer
+      (mapc (lambda (m) (lui-insert m t)) (reverse messages))
+      (slack-buffer-set-current-room room)
+      (goto-char (point-max)))
     buffer))
 
 (defun slack-buffer-update (buf-name text)
@@ -55,9 +61,9 @@
           (lui-insert text)))))
 
 (defun slack-buffer-update-notification (buf-name string)
-  (let ((buffer (get-buffer-create buf-name)))
+  (let ((buffer (slack-get-buffer-create buf-name)))
     (with-current-buffer buffer
-      (lui-insert text))))
+      (lui-insert string))))
 
 (provide 'slack-buffer)
 ;;; slack-buffer.el ends here


### PR DESCRIPTION
Hi,

I ran into your project through [this](https://www.reddit.com/r/emacs/comments/3uqork/someone_is_working_on_another_slack_client/) reddit thread. I've been wanting to try and write an Emacs Slack client for awhile and just felt like I could get around to it when I read that thread. So I immediately tried out your client.

It was a bit of a challenge. First trying to find out where to find the client id and secret and the token, which would have been much easier if I'd paid more attention to the README. And then how to send a message. `M-x slack-message-send RET My message C-j` is not exactly my idea of a frictionless workflow. It was also a bit strange to find that `RET` in the minibuffer added a newline instead of sending the message.

Anyway, I thought that it would be great to have a prompt at the bottom of the room buffer where messages could be typed and sending was as easy as pressing `RET`, much like ERC, Circe, jabber.el and probably others. I also thought that Circe's `lui.el` implemented much of this, so I wanted to try and hack together emacs-slack and `lui.el`. Here I present to you my first draft. I've been testing it with my work Slack account a bit and I like the way it works. Now I would appreciate your opinion on this.

Using `lui.el` takes care of a few things. It allows us to easily add a prompt and send messages by using that prompt, takes care of showing the messages before the prompt (and keeping them read-only) and shows notifications in the modeline, to name a few.

Of course it's a bit weird that this also introduces a dependency on Circe, but perhaps if you like it and want to develop on this further, we could ask the Circe people if it is possible to split the `lui.el` into its own project.

In any case, great work on this project, I'm very happy that I ran into it. Thanks in advance for your time.


Cheers,

Tom