### PR TITLE
Add package definition

### DIFF
--- a/slack-pkg.el
+++ b/slack-pkg.el
@@ -1,0 +1,8 @@
+(define-package "slack" "0"
+  "Slack client for Emacs"
+  '((websocket "1.5")
+    (request "0.2.0")
+    (oauth2 "0.10")
+    (circe "2.1")
+    (popup "0.5.3")
+    (emojify "0.2")))

--- a/slack.el
+++ b/slack.el
@@ -96,6 +96,7 @@ set this to save request to Slack if already have.")
     (setq slack-token
           (oauth2-token-access-token slack-oauth2-token))))
 
+;;;###autoload
 (defun slack-start ()
   (interactive)
   (if slack-ws


### PR DESCRIPTION
Hi again,

I use `package.el` for all my package installations, and it'd be great if emacs-slack could support this as well. This greatly simplifies installing and testing this package and in the future will help to get this package into repositories like Melpa, if you're interested in that.

I've added a single autoload, because as I think `slack-start` is the only real entry point into this package, but if there are others, please let me know and I'll add them.

I've picked version 0 for this package to start with to indicate that no releases have been made yet. When you feel comfortable releasing/tagging a first version we should change this. I'm partial to using [Semantic Versioning](http://semver.org/), but it is of course your call.

For the dependencies I've taken the latest I found on either the gnu elpa repository or melpa stable. I don't know if emacs-slack actually works with each of these package versions or if it requires the latest git version. I usually intall packages from Melpa and so always have the latest git versions. I should maybe test this.

Please let me know what you think.