### PR TITLE
Fix for older Emacs

### DIFF
--- a/slack-message.el
+++ b/slack-message.el
@@ -102,13 +102,13 @@
    (image-url :initarg :image_url)
    (thumb-url :initarg :thumb_url)))
 
-(cl-defgeneric slack-message-sender-name  (slack-message))
-(cl-defgeneric slack-message-to-string (slack-message))
-(cl-defgeneric slack-message-to-alert (slack-message))
-(cl-defgeneric slack-message-notify-buffer (slack-message))
+(defgeneric slack-message-sender-name  (slack-message))
+(defgeneric slack-message-to-string (slack-message))
+(defgeneric slack-message-to-alert (slack-message))
+(defgeneric slack-message-notify-buffer (slack-message))
 
-(cl-defgeneric slack-room-buffer-name (room))
-(cl-defgeneric slack-room-update-messages (room))
+(defgeneric slack-room-buffer-name (room))
+(defgeneric slack-room-update-messages (room))
 
 (defun slack-room-find (id)
   (cl-labels ((find-room (room)
@@ -176,7 +176,7 @@
   (and (string= (oref m ts) (oref n ts))
        (string= (oref m text) (oref n text))))
 
-(cl-defmethod slack-message-update ((m slack-message) &key replace)
+(defmethod slack-message-update ((m slack-message) &key replace)
   (with-slots (room channel) m
     (let ((room (or room (slack-room-find channel))))
       (when room

--- a/slack-room.el
+++ b/slack-room.el
@@ -43,10 +43,10 @@
    (unread-count-display :initarg :unread_count_display :initform 0 :type integer)
    (messages :initarg :messages :initform ())))
 
-(cl-defgeneric slack-room-name (room))
-(cl-defgeneric slack-room-history (room))
-(cl-defgeneric slack-room-buffer-header (room))
-(cl-defgeneric slack-room-update-mark-url (room))
+(defgeneric slack-room-name (room))
+(defgeneric slack-room-history (room))
+(defgeneric slack-room-buffer-header (room))
+(defgeneric slack-room-update-mark-url (room))
 
 (defmethod slack-room-subscribedp ((_room slack-room))
   nil)


### PR DESCRIPTION
cl-defmethod and cl-defgeneric are implemented only in development Emacs.
So to use them causes error("no such function") on older Emacs.

I got following error when I loaded slack.el.

```
slack.el:31:1:Error: Symbol's function definition is void: cl-defgeneric
```