### PR TITLE
Bind lui-time-stamp-time when inserting messages in a buffer

### DIFF
--- a/slack-buffer.el
+++ b/slack-buffer.el
@@ -45,6 +45,8 @@
 (defvar slack-current-room)
 (make-local-variable 'slack-current-room)
 
+(defvar slack-current-message nil)
+
 (defcustom slack-buffer-emojify nil
   "Show emoji with `emojify' if true."
   :group 'slack)
@@ -54,7 +56,9 @@
     (unless buffer
       (setq buffer (generate-new-buffer buf-name))
       (with-current-buffer buffer
-        (slack-mode)))
+        (slack-mode)
+        (add-hook 'lui-pre-output-hook 'slack-buffer-add-last-ts-property nil t)
+        (add-hook 'lui-post-output-hook 'slack-buffer-add-ts-property nil t)))
     buffer))
 
 (defun slack-buffer-set-current-room (room)
@@ -89,12 +93,31 @@
                                         map))
                   "\n")))
 
+(defun slack-buffer-add-last-ts-property ()
+  (when slack-current-message
+    (add-text-properties
+     (point-min) (point-max)
+     `(slack-last-ts ,lui-time-stamp-last))))
+
+(defun slack-buffer-add-ts-property ()
+  (when slack-current-message
+    (add-text-properties
+     (point-min) (point-max)
+     `(ts ,(oref slack-current-message ts)))))
+
+(defun slack-buffer-insert (message &optional not-tracked-p)
+  (let ((lui-time-stamp-time (slack-message-time-stamp message))
+        (beg lui-input-marker)
+        (inhibit-read-only t))
+    (let ((slack-current-message message))
+      (lui-insert (slack-message-to-string message) not-tracked-p))))
+
 (defun slack-buffer-insert-messages (room)
   (let ((messages (slack-room-latest-messages room)))
     (when messages
       (slack-buffer-insert-previous-link (cl-first messages))
       (mapc (lambda (m)
-              (lui-insert (slack-message-to-string m) t))
+              (slack-buffer-insert m t))
             messages)
       (let ((latest-message (car (last messages))))
         (slack-room-update-last-read room latest-message)
@@ -104,7 +127,7 @@
   (cl-labels ((do-update (buf room msg)
                          (with-current-buffer buf
                            (slack-room-update-last-read room msg)
-                           (lui-insert (slack-message-to-string msg)))))
+                           (slack-buffer-insert msg))))
     (let* ((buf-name (slack-room-buffer-name room))
            (buffer (get-buffer buf-name))
            (buf-names (mapcar #'buffer-name (mapcar #'window-buffer
@@ -119,12 +142,13 @@
   (with-current-buffer buffer
     (let* ((cur-point (point))
            (beg (text-property-any (point-min) (point-max) 'ts (oref msg ts)))
-           (end (next-single-property-change beg 'ts)))
+           (end (next-single-property-change beg 'ts))
+           (lui-time-stamp-last (get-text-property beg 'slack-last-ts)))
       (if (and beg end)
           (let ((inhibit-read-only t))
-            (delete-region beg (+ end 1))
+            (delete-region beg end)
             (set-marker lui-output-marker beg)
-            (lui-insert (slack-message-to-string msg))
+            (slack-buffer-insert msg)
             (goto-char cur-point)
             (slack-buffer-recover-lui-output-marker))))))
 

--- a/slack-buffer.el
+++ b/slack-buffer.el
@@ -38,7 +38,6 @@
 (define-derived-mode slack-mode lui-mode "Slack"
   ""
   (lui-set-prompt lui-prompt-string)
-  (setq lui-time-stamp-position nil)
   (setq lui-fill-type nil)
   (setq lui-input-function 'slack-message--send))
 

--- a/slack-message-formatter.el
+++ b/slack-message-formatter.el
@@ -79,10 +79,7 @@
       (mapconcat #'slack-reaction-to-string reactions " ")))
 
 (defmethod slack-message-header ((m slack-message))
-  (with-slots (ts) m
-      (let ((name (slack-message-sender-name m))
-            (time (slack-message-time-to-string ts)))
-        (format "%s %s" name time))))
+  (slack-message-sender-name m))
 
 (defmethod slack-message-to-string ((m slack-message))
   (with-slots (text reactions attachments) m

--- a/slack-message.el
+++ b/slack-message.el
@@ -232,5 +232,8 @@
        :success #'on-pins-add
        :sync nil))))
 
+(defun slack-message-time-stamp (message)
+  (seconds-to-time (string-to-number (oref message ts))))
+
 (provide 'slack-message)
 ;;; slack-message.el ends here

--- a/slack-pkg.el
+++ b/slack-pkg.el
@@ -3,6 +3,6 @@
   '((websocket "1.5")
     (request "0.2.0")
     (oauth2 "0.10")
-    (circe "2.1")
+    (circe "2.2")
     (alert "1.2")
     (emojify "0.2")))

--- a/slack-room.el
+++ b/slack-room.el
@@ -159,7 +159,7 @@
          (let ((inhibit-read-only t)
                (loading-message-end (next-single-property-change
                                      cur-point
-                                     'oldest))
+                                     'slack-last-ts))
                (prev-messages (slack-room-prev-messages room oldest)))
            (delete-region (point-min) loading-message-end)
            (set-marker lui-output-marker (point-min))

--- a/slack-user-message.el
+++ b/slack-user-message.el
@@ -20,7 +20,7 @@
     (let* ((name (slack-message-sender-name m))
            (time (slack-message-time-to-string ts))
            (edited-at (slack-message-time-to-string edited-at))
-           (header (format "%s %s" name time)))
+           (header (format "%s" name)))
       (if edited-at
           (format "%s edited_at: %s" header edited-at)
         header))))


### PR DESCRIPTION
Hi,

As discussed in a previous pull request I was able send a patch to the Circe maintainer that allows us to change the time stamp lui outputs when inserting a message.

This change is only available in the latest git revisions of Circe and hasn't been officially released yet. I've upped the minimum required version in the pkg file to reflect that the next version released will be required. This should be fine for Melpa right now since any Melpa version should be higher than 2.2. Anyone using Melpa Stable instead would have trouble since 2.2 isn't on there yet. This shouldn't be an issue right now since there are no tags in this project yet, so it shouldn't show up on Melpa Stable.

I removed the time stamp from the message header because I didn't see the point in showing it twice.

I also removed the setting of `lui-time-stamp-position`, since this will also affect my Circe buffers, as this isn't a buffer-local setting, nor is it set buffer-locally (this is also true for `lui-fill-type`).

Please let me know what you think.


Cheers,

Tom