### PR TITLE
Use cl-lib macro instead of cl.el

### DIFF
--- a/slack-buffer.el
+++ b/slack-buffer.el
@@ -92,7 +92,7 @@
 (defun slack-buffer-insert-messages (room)
   (let ((messages (slack-room-latest-messages room)))
     (when messages
-      (slack-buffer-insert-previous-link (first messages))
+      (slack-buffer-insert-previous-link (cl-first messages))
       (mapc (lambda (m)
               (lui-insert (slack-message-to-string m) t))
             messages)

--- a/slack-room.el
+++ b/slack-room.el
@@ -167,7 +167,7 @@
            (set-marker lui-output-marker (point-min))
            (if prev-messages
                (progn
-                 (slack-buffer-insert-previous-link (first prev-messages))
+                 (slack-buffer-insert-previous-link (cl-first prev-messages))
                  (mapc (lambda (m)
                          (lui-insert (slack-message-to-string m)))
                        prev-messages))


### PR DESCRIPTION
This fixes following byte-compile warnings.

```
In end of data:
slack-room.el:287:1:Warning: the function `first' is not known to be defined.

In end of data:
slack-buffer.el:154:1:Warning: the following functions are not known to be define\
d: first
```