### PR TITLE
Handle bot messages without text

### DIFF
--- a/slack-bot-message.el
+++ b/slack-bot-message.el
@@ -43,11 +43,13 @@
     (oref m username)))
 
 (defmethod slack-message-to-alert ((m slack-bot-message))
-  (with-slots (text attachments) m
-    (if (< 0 (length text))
+  (let ((text (if (slot-boundp m 'text)
+                  (oref m text))))
+    (with-slots (attachments) m
+      (if (and text (< 0 (length text)))
           (slack-message-unescape-string text)
-      (let ((attachment-string (mapconcat #'slack-attachment-to-alert attachments " ")))
-        (slack-message-unescape-string attachment-string)))))
+        (let ((attachment-string (mapconcat #'slack-attachment-to-alert attachments " ")))
+          (slack-message-unescape-string attachment-string))))))
 
 (defmethod slack-message-sender-name ((m slack-bot-message))
   (slack-bot-name m))

--- a/slack-message-formatter.el
+++ b/slack-message-formatter.el
@@ -82,24 +82,26 @@
   (slack-message-sender-name m))
 
 (defmethod slack-message-to-string ((m slack-message))
-  (with-slots (text reactions attachments) m
-    (let* ((header (slack-message-header m))
-           (attachment-string (mapconcat #'slack-attachment-to-string
-                                         attachments "\n"))
-           (body (slack-message-unescape-string
-                  (concat text attachment-string)))
-           (reactions-str (slack-message-reactions-to-string
-                           reactions)))
-      (slack-message-put-header-property header)
-      (slack-message-put-text-property body)
-      (slack-message-put-reactions-property reactions-str)
-      (slack-message-propertize m
-                                (concat header "\n"
-                                        body "\n"
-                                        (if reactions-str
-                                            (concat "\n"
-                                                    reactions-str
-                                                    "\n")))))))
+  (let ((text (if (slot-boundp m 'text)
+                  (oref m text))))
+    (with-slots (reactions attachments) m
+      (let* ((header (slack-message-header m))
+             (attachment-string (mapconcat #'slack-attachment-to-string
+                                           attachments "\n"))
+             (body (slack-message-unescape-string
+                    (concat text attachment-string)))
+             (reactions-str (slack-message-reactions-to-string
+                             reactions)))
+        (slack-message-put-header-property header)
+        (slack-message-put-text-property body)
+        (slack-message-put-reactions-property reactions-str)
+        (slack-message-propertize m
+                                  (concat header "\n"
+                                          body "\n"
+                                          (if reactions-str
+                                              (concat "\n"
+                                                      reactions-str
+                                                      "\n"))))))))
 
 (defmethod slack-message-to-alert ((m slack-message))
   (with-slots (text) m


### PR DESCRIPTION
Hi,

Certain bot messages (namely those from the Pivotal Tracker integration) don't specify a text and only offer text from attachments. When this happens the text slot is unbound and `with-slots` fails to get the
`text` slot.

Alternatively I could set the `:initform` of the `slack-message` class, but having tried that I get an error that there is no applicable method of `slack-message-notify-buffer` for `slack-bot-message`. I got this change done first, but if you prefer the other I'll change it.