### PR TITLE
Add url description

### DIFF
--- a/slack-pkg.el
+++ b/slack-pkg.el
@@ -5,4 +5,5 @@
     (oauth2 "0.10")
     (circe "2.2")
     (alert "1.2")
-    (emojify "0.2")))
+    (emojify "0.2"))
+  :url "https://github.com/yuya373/emacs-slack")


### PR DESCRIPTION
This will add to package information the URL. e.g.

```
slack is an available package.

     Status: Available from sandbox -- [Install]
    Archive: sandbox
    Version: 20160513.1710
   Requires: websocket-1.5, request-0.2.0, oauth2-0.10, circe-2.2, alert-1.2, emojify-0.2
    Summary: Slack client for Emacs
   Homepage: https://github.com/yuya373/emacs-slack
    Other versions: 20160422.908 (melpa).
```