### PR TITLE
Fix README: Not slack-enable-emoji but slack-buffer-emojify

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ emacs client for Slack
 (use-package slack
   :commands (slack-start)
   :init
-  (setq slack-enable-emoji t) ;; if you want to enable emoji, default nil
+  (setq slack-buffer-emojify t) ;; if you want to enable emoji, default nil
   (setq slack-prefer-current-team t)
   :config
   (slack-register-team


### PR DESCRIPTION
This fixes obsolete variable in README.