### PR TITLE
Escape & link messages

### DIFF
--- a/slack-message-formatter.el
+++ b/slack-message-formatter.el
@@ -160,7 +160,7 @@
   (let ((channel-regexp "<#\\(C.*?\\)|\\(.*?\\)>"))
     (cl-labels ((unescape-channel
                  (text)
-                 (concat "@" (or (match-string 2 text)
+                 (concat "#" (or (match-string 2 text)
                                  (slack-room-find
                                   (match-string 1 text))
                                  (match-string 1 text)))))

--- a/slack-message-sender.el
+++ b/slack-message-sender.el
@@ -62,7 +62,11 @@
               (id (slack-user-get-id username team)))
          (if id
              (format "<@%s|%s>" id username)
-           text)))
+           (cond
+            ((string= username "here") "<!here|here>")
+            ((find username '("channel" "group") :test #'string=) "<!channel>")
+            ((string= username "everyone") "<!everyone>")
+            (t text)))))
    message t))
 
 (defun slack-link-channels (message team)
@@ -152,23 +156,19 @@
        (alist "Select Channel: ")
        (let* ((room selected)
               (room-name (slack-room-name room)))
-         (insert (concat "<#" (oref room id) "|" room-name "> ")))))))
+         (insert (concat "#" room-name)))))))
 
 (defun slack-message-embed-mention ()
   (interactive)
   (let ((team (slack-team-select)))
-    (let* ((pre-defined (list (cons "here" "here")
-                              (cons "channel" "channel")))
+    (let* ((pre-defined (list (list "here" :name "here")
+                              (list "channel" :name "channel")))
            (alist (append pre-defined (slack-user-names team))))
       (slack-select-from-list
        (alist "Select User: ")
-       (let ((user-id (plist-get selected :id)))
-         (if (or (string= user-id "here")
-                 (string= user-id "channel"))
-             (insert (concat "<!" selected "> "))
-           (let* ((user-name (slack-user-name user-id team)))
-             (insert (concat "<@" user-id "|" user-name "> ")))))))))
+       (insert (concat "@" (plist-get selected :name)))))))
 
+(slack-user-names slack-current-team)
 
 (provide 'slack-message-sender)
 ;;; slack-message-sender.el ends here

--- a/slack-message-sender.el
+++ b/slack-message-sender.el
@@ -80,6 +80,7 @@
            (if id
                (format "<#%s|%s>" id channel)
              text)))
+     message t)))
 
 (defun slack-message--send (message)
   (if slack-current-team-id

--- a/slack-message-sender.el
+++ b/slack-message-sender.el
@@ -166,7 +166,5 @@
        (alist "Select User: ")
        (insert (concat "@" (plist-get selected :name)))))))
 
-(slack-user-names slack-current-team)
-
 (provide 'slack-message-sender)
 ;;; slack-message-sender.el ends here

--- a/slack-message-sender.el
+++ b/slack-message-sender.el
@@ -154,9 +154,7 @@
     (let* ((alist (slack-channel-names team)))
       (slack-select-from-list
        (alist "Select Channel: ")
-       (let* ((room selected)
-              (room-name (slack-room-name room)))
-         (insert (concat "#" room-name)))))))
+       (insert (concat "#" (slack-room-name selected)))))))
 
 (defun slack-message-embed-mention ()
   (interactive)


### PR DESCRIPTION
  - Escape '<>&' in outgoing messages.
  - Link @-references to users & #-references to channels.

This is taken from the Slack API docs at https://api.slack.com/docs/formatting. It doesn't do anything about bang-commands (e.g. <!here>).