### PR TITLE
on buffer update, create buffer if it doesn't yet exist

### DIFF
--- a/slack-buffer.el
+++ b/slack-buffer.el
@@ -211,8 +211,7 @@
 
 (cl-defun slack-buffer-update (room msg team &key replace)
   (let* ((buf-name (slack-room-buffer-name room))
-         (buffer (or (get-buffer buf-name)
-                     (and slack-buffer-create-on-notify (slack-room-make-buffer-with-room room team)))))
+         (buffer (get-buffer buf-name)))
     (if buffer
         (progn
           (if (slack-buffer-in-current-frame buffer)
@@ -223,7 +222,8 @@
             (with-current-buffer buffer
               (slack-room-update-last-read room msg)
               (slack-buffer-insert msg team))))
-      (slack-room-inc-unread-count room))))
+      (slack-room-inc-unread-count room)
+      (and slack-buffer-create-on-notify (slack-room-make-buffer-with-room room team)))))
 
 (defmacro slack-buffer-goto-char (find-point &rest else)
   `(let* ((cur-point (point))

--- a/slack-buffer.el
+++ b/slack-buffer.el
@@ -223,7 +223,7 @@
               (slack-room-update-last-read room msg)
               (slack-buffer-insert msg team))))
       (slack-room-inc-unread-count room)
-      (and slack-buffer-create-on-notify (slack-room-make-buffer-with-room room team)))))
+      (and slack-buffer-create-on-notify (slack-room-make-buffer-with-room-bg room team)))))
 
 (defmacro slack-buffer-goto-char (find-point &rest else)
   `(let* ((cur-point (point))

--- a/slack-buffer.el
+++ b/slack-buffer.el
@@ -208,18 +208,18 @@
 
 (cl-defun slack-buffer-update (room msg team &key replace)
   (let* ((buf-name (slack-room-buffer-name room))
-         (buffer (get-buffer buf-name)))
-    (if buffer
-        (progn
-          (if (slack-buffer-in-current-frame buffer)
-              (slack-room-update-mark room team msg)
-            (slack-room-inc-unread-count room))
-          (if replace
-              (slack-buffer-replace buffer msg)
-            (with-current-buffer buffer
-              (slack-room-update-last-read room msg)
-              (slack-buffer-insert msg team))))
-      (slack-room-inc-unread-count room))))
+         (buffer (or (get-buffer buf-name)
+                     (slack-room-make-buffer-with-room room team))))
+    (progn
+      (if (slack-buffer-in-current-frame buffer)
+          (slack-room-update-mark room team msg)
+        (slack-room-inc-unread-count room))
+      (if replace
+          (slack-buffer-replace buffer msg)
+        (with-current-buffer buffer
+          (slack-room-update-last-read room msg)
+          (slack-buffer-insert msg team))))
+    (slack-room-inc-unread-count room)))
 
 (defmacro slack-buffer-goto-char (find-point &rest else)
   `(let* ((cur-point (point))

--- a/slack-message-sender.el
+++ b/slack-message-sender.el
@@ -64,7 +64,7 @@
              (format "<@%s|%s>" id username)
            (cond
             ((string= username "here") "<!here|here>")
-            ((find username '("channel" "group") :test #'string=) "<!channel>")
+            ((cl-find username '("channel" "group") :test #'string=) "<!channel>")
             ((string= username "everyone") "<!everyone>")
             (t text)))))
    message t))

--- a/slack-room.el
+++ b/slack-room.el
@@ -105,6 +105,13 @@
     (funcall slack-buffer-function
              (slack-buffer-create room team))))
 
+(cl-defun slack-room-make-buffer-with-room-bg (room team)
+  (if (< (length (oref room messages)) 1)
+      (slack-room-history room team nil
+                          #'(slack-buffer-create room team)
+                          t)
+    (slack-buffer-create room team)))
+
 (cl-defmacro slack-select-from-list ((alist prompt) &body body)
   "Bind candidates from selected."
   (let ((key (cl-gensym)))

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -469,7 +469,7 @@
         (progn
           (slack-notify-abandon-reconnect)
           (slack-ws-cancel-reconnect-timer team))
-      (incf reconnect-count)
+      (cl-incf reconnect-count)
       (slack-ws-close team)
       (slack-authorize
        team

--- a/slack.el
+++ b/slack.el
@@ -5,7 +5,7 @@
 ;; Author: yuya.minami <yuya.minami@yuyaminami-no-MacBook-Pro.local>
 ;; Keywords: tools
 ;; Version: 0.0.2
-;; Package-Requires: ((websocket "1.5") (request "0.2.0") (oauth2 "0.10") (circe "2.3") (alert "1.2") (emojify "0.4") (emacs "24.3"))
+;; Package-Requires: ((websocket "1.5") (request "0.2.0") (oauth2 "0.10") (circe "2.3") (alert "1.2") (emojify "0.4") (emacs "24.4"))
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
@@ -25,6 +25,7 @@
 
 ;;; Code:
 (require 'cl-lib)
+(require 'subr-x)
 (require 'oauth2)
 
 (require 'slack-team)


### PR DESCRIPTION
If one uses osd notifications she wouldn't ever find out if she was notified on channel if buffer is not open. This patch fixes it.
