### PR TITLE
Update minimum Emacs version

### DIFF
--- a/slack.el
+++ b/slack.el
@@ -5,7 +5,7 @@
 ;; Author: yuya.minami <yuya.minami@yuyaminami-no-MacBook-Pro.local>
 ;; Keywords: tools
 ;; Version: 0.0.2
-;; Package-Requires: ((websocket "1.5") (request "0.2.0") (oauth2 "0.10") (circe "2.3") (alert "1.2") (emojify "0.4") (emacs "24.3"))
+;; Package-Requires: ((websocket "1.5") (request "0.2.0") (oauth2 "0.10") (circe "2.3") (alert "1.2") (emojify "0.4") (emacs "24.4"))
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
@@ -25,6 +25,7 @@
 
 ;;; Code:
 (require 'cl-lib)
+(require 'subr-x)
 (require 'oauth2)
 
 (require 'slack-team)


### PR DESCRIPTION
- hash-table-keys which is defined in subr-x.el was introduced at Emacs 24.4.
- And load subr-x in slack.el