### PR TITLE
basic mpim support + some additional configurability

### DIFF
--- a/slack-im.el
+++ b/slack-im.el
@@ -45,7 +45,7 @@
    (is-open :initarg :is_open :initform nil)))
 
 (defmethod slack-room-open-p ((room slack-im))
-  (oref room is-open))
+  t)
 
 (defmethod slack-room-name-with-team-name ((room slack-im))
   (with-slots (team-id user) room

--- a/slack-message-notification.el
+++ b/slack-message-notification.el
@@ -37,6 +37,16 @@
   "Custom notification function.\ntake 3 Arguments.\n(lambda (MESSAGE ROOM TEAM) ...)."
   :group 'slack)
 
+(defcustom slack-message-im-notification-title-format-function (apply-partially #'format "%s - %s")
+  "Function to format notification title for IM message.\ntake 2 Arguments.\n(lambda (TEAM-NAME ROOM-NAME) ...)."
+  :type 'function
+  :group 'slack)
+
+(defcustom slack-message-notification-title-format-function (apply-partially #'format "%s - #%s")
+  "Function to format notification title for non-IM message.\ntake 2 Arguments.\n(lambda (TEAM-NAME ROOM-NAME) ...)."
+  :type 'function
+  :group 'slack)
+
 (defun slack-message-notify (message room team)
   (if slack-message-custom-notifier
       (funcall slack-message-custom-notifier message room team)
@@ -62,8 +72,8 @@
             (setq text (concat "\\" text)))
         (alert (if (slack-im-p room) text (format "%s: %s" user-name text))
                :title (if (slack-im-p room)
-                          (format "%s - %s" team-name room-name)
-                        (format "%s - #%s" team-name room-name))
+                          (funcall slack-message-im-notification-title-format-function team-name room-name)
+                        (funcall slack-message-notification-title-format-function team-name room-name))
                :category 'slack))))
 
 (defmethod slack-message-sender-equalp ((_m slack-message) _sender-id)

--- a/slack-room.el
+++ b/slack-room.el
@@ -108,7 +108,7 @@
 (cl-defun slack-room-make-buffer-with-room-bg (room team)
   (if (< (length (oref room messages)) 1)
       (slack-room-history room team nil
-                          #'(slack-buffer-create room team)
+                          #'(lambda () (slack-buffer-create room team))
                           t)
     (slack-buffer-create room team)))
 

--- a/slack-room.el
+++ b/slack-room.el
@@ -211,38 +211,33 @@
     (let ((team (slack-team-find team-id)))
       (format "%s - %s" (oref team name) name))))
 
+(defmethod slack-room-label ((room slack-room))
+  (format "%s%s%s"
+          (if (object-of-class-p room 'slack-im)
+              (slack-im-user-presence room)
+            "  ") 
+          (slack-room-name-with-team-name room)
+          (with-slots (unread-count-display) room
+            (if (< 0 unread-count-display)
+                (concat " ("
+                        (number-to-string unread-count-display)
+                        ")")
+              ""))))
+
 (defmacro slack-room-names (rooms &optional filter)
   `(cl-labels
        ((latest-ts (room)
                    (with-slots (latest) room
                      (if latest (oref latest ts) "0")))
-        (unread-count (room)
-                      (with-slots (unread-count-display) room
-                        (if (< 0 unread-count-display)
-                            (concat "("
-                                    (number-to-string unread-count-display)
-                                    ")")
-                          "")))
         (sort-rooms (rooms)
                     (nreverse
                      (cl-sort rooms #'string<
-                              :key #'(lambda (name-with-room) (latest-ts (cdr name-with-room))))))
-        (build-label (room)
-                     (concat (im-presence room)
-                             (format "%s %s"
-                                     (slack-room-name-with-team-name room)
-                                     (unread-count room))))
-        (im-presence (room)
-                     (if (object-of-class-p room 'slack-im)
-                         (slack-im-user-presence room)
-                       "  "))
-        (build-cons (room)
-                    (cons (build-label room) room)))
+                              :key #'(lambda (name-with-room) (latest-ts (cdr name-with-room)))))))
      (sort-rooms
       (cl-loop for room in (if ,filter
                                (funcall ,filter ,rooms)
                              ,rooms)
-               collect (cons (build-label room) room)))))
+               collect (cons (slack-room-label room) room)))))
 
 (defmethod slack-room-name ((room slack-room))
   (oref room name))

--- a/slack-room.el
+++ b/slack-room.el
@@ -106,11 +106,14 @@
              (slack-buffer-create room team))))
 
 (cl-defun slack-room-make-buffer-with-room-bg (room team)
-  (if (< (length (oref room messages)) 1)
-      (slack-room-history room team nil
-                          #'(lambda () (slack-buffer-create room team))
-                          t)
-    (slack-buffer-create room team)))
+  (cl-labels ((create-buffer ()
+                             (tracking-add-buffer (slack-buffer-create room team))
+                             ))
+    (if (< (length (oref room messages)) 1)
+        (slack-room-history room team nil
+                            #'(lambda () (create-buffer))
+                            t)
+      (create-buffer))))
 
 (cl-defmacro slack-select-from-list ((alist prompt) &body body)
   "Bind candidates from selected."

--- a/slack.el
+++ b/slack.el
@@ -120,7 +120,7 @@ never means never show typing indicator."
         (mapcar #'(lambda (data)
                     (slack-room-create data team class))
                 (append
-                 (cl-remove-if-not #'(lambda (data) (plist-get data :is_open)) datum)
+                 (cl-remove-if #'(lambda (data) (eq (plist-get data :is_open) json-false)) datum)
                  nil))))
     (let ((self (plist-get data :self))
           (team-data (plist-get data :team)))

--- a/slack.el
+++ b/slack.el
@@ -104,7 +104,7 @@ never means never show typing indicator."
                     :success (cl-function (lambda (&key data &allow-other-keys)
                                             (slack-on-authorize data team)))
                     :sync nil
-                    :params (list (cons "mpim_aware" t))
+                    :params (list (cons "mpim_aware" "1"))
                     :error error-callback)))
       (push request slack-authorize-requests))))
 
@@ -120,7 +120,7 @@ never means never show typing indicator."
         (mapcar #'(lambda (data)
                     (slack-room-create data team class))
                 (append
-                 (cl-remove-if #'(lambda (data) (plist-get data :is_open)) datum)
+                 (cl-remove-if-not #'(lambda (data) (plist-get data :is_open)) datum)
                  nil))))
     (let ((self (plist-get data :self))
           (team-data (plist-get data :team)))


### PR DESCRIPTION
Few more things I was missing:
1. basic mpim support
2. few titles are configurable (team name in front of every room is quite annoying)
3. im rooms are always open so it's not required to open them by hand. All im's are listed in slack-room-select right away
4. fix for background buffer creation when history load is required.