### PR TITLE
Go to the input marker after setting up a buffer

### DIFF
--- a/slack-buffer.el
+++ b/slack-buffer.el
@@ -69,6 +69,7 @@
       (with-current-buffer buffer
         (slack-mode)
         (slack-buffer-insert-previous-link room)
+        (goto-char lui-input-marker)
         (add-hook 'kill-buffer-hook 'slack-reset-room-last-read nil t)
         (add-hook 'lui-pre-output-hook 'slack-buffer-buttonize-link nil t)))
     buffer))


### PR DESCRIPTION
I've been looking at the functions responsible for creating and filling the buffers. `slack-buffer-widen` also uses `save-excursion`, and it seems that all the text insertion functions in turn use `slack-buffer-widen`, so point is never advanced beyond `(point-min)`.

I think this might also fix #128

---

This way users don’t have to move the cursor to the end of the buffer
themselves. Going to ‘(point-max)’ works just as well, but it seems
more accurate to go to the ‘lui-input-marker’, since we want users to
be able to start typing immediately.