### PR TITLE
Fix bug with attachments in chats

### DIFF
--- a/slack-message-formatter.el
+++ b/slack-message-formatter.el
@@ -95,9 +95,11 @@
   text)
 
 (defun slack-message-time-to-string (ts)
-  (if ts
-      (format-time-string "%Y-%m-%d %H:%M:%S"
-                          (seconds-to-time (string-to-number ts)))))
+  (when ts
+    (when (stringp ts)
+      (setf ts (string-to-number ts)))
+    (format-time-string "%Y-%m-%d %H:%M:%S"
+                        (seconds-to-time ts))))
 
 (defun slack-message-reactions-to-string (reactions)
   (if reactions


### PR DESCRIPTION
Sometimes SLACK-MESSAGE-TIME-TO-STRING gets called with a string and
sometimes it gets called with a number; calling STRING-TO-NUMBER on a
string results in an error.

It'd be nice to fix the underlying reason why it sometimes gets a
string and sometimes a number …