### PR TITLE
only delete editor window if there are more windows in frame

### DIFF
--- a/slack-message-editor.el
+++ b/slack-message-editor.el
@@ -204,7 +204,7 @@
         ('new (slack-message--send buf-string))
         ('thread-message-new (slack-thread-message--send buf-string)))
       (kill-buffer)
-      (delete-window))))
+      (if (> (count-windows) 1) delete-window))))
 
 (defun slack-message--edit (channel team ts text)
   (cl-labels ((on-edit (&key data &allow-other-keys)


### PR DESCRIPTION
A small fix to avoid error message on edit window close in case it was using whole frame