### PR TITLE
Configure display team name

### DIFF
--- a/slack-channel.el
+++ b/slack-channel.el
@@ -50,7 +50,7 @@
 (defmethod slack-room-buffer-name ((room slack-channel))
   (concat slack-channel-buffer-name
           " : "
-          (slack-room-name-with-team-name room)))
+          (slack-room-display-name room)))
 
 (defun slack-channel-names (team &optional filter)
   (with-slots (channels) team
@@ -167,7 +167,7 @@
                (let ((channel (slack-room-create c-data team 'slack-channel)))
                  (with-slots (channels) team (push channel channels))
                  (message "Channel: %s created"
-                          (slack-room-name-with-team-name channel))))))))
+                          (slack-room-display-name channel))))))))
     (slack-channel-fetch-info id team #'on-create-from-info)))
 
 (defun slack-channel-fetch-info (id team success)

--- a/slack-group.el
+++ b/slack-group.el
@@ -68,7 +68,7 @@
 (defmethod slack-room-buffer-name ((room slack-group))
   (concat slack-group-buffer-name
           " : "
-          (slack-room-name-with-team-name room)))
+          (slack-room-display-name room)))
 
 (defun slack-group-select ()
   (interactive)
@@ -138,7 +138,7 @@
                                      (slack-room-equal-p group g))
                                  groups)))
            (message "Left Group: %s"
-                    (slack-room-name-with-team-name group)))))
+                    (slack-room-display-name group)))))
       (slack-room-request-with-id slack-group-leave-url
                                   (oref group id)
                                   team

--- a/slack-im.el
+++ b/slack-im.el
@@ -172,5 +172,8 @@
         :success #'on-success
         :sync nil)))))
 
+(defmethod slack-room-label-prefix ((room slack-im))
+  (slack-im-user-presence room))
+
 (provide 'slack-im)
 ;;; slack-im.el ends here

--- a/slack-im.el
+++ b/slack-im.el
@@ -76,7 +76,7 @@
 (defmethod slack-room-buffer-name ((room slack-im))
   (concat slack-im-buffer-name
           " : "
-          (slack-room-name-with-team-name room)))
+          (slack-room-display-name room)))
 
 (defun slack-im-select ()
   (interactive)

--- a/slack-im.el
+++ b/slack-im.el
@@ -46,12 +46,6 @@
 (defmethod slack-room-open-p ((room slack-im))
   t)
 
-(defmethod slack-room-name-with-team-name ((room slack-im))
-  (with-slots (team-id user) room
-    (let* ((team (slack-team-find team-id))
-           (user-name (slack-user-name user team)))
-      (format "%s - %s" (oref team name) user-name))))
-
 (defmethod slack-im-user-presence ((room slack-im))
   (with-slots ((user-id user) team-id) room
     (let* ((team (slack-team-find team-id))

--- a/slack-message-delete.el
+++ b/slack-message-delete.el
@@ -91,7 +91,7 @@
     (when message
       (alert "message deleted"
              :title (format "\\[%s] from %s"
-                            (slack-room-name-with-team-name room)
+                            (slack-room-display-name room)
                             (slack-message-sender-name message team))
              :category 'slack))))
 

--- a/slack-message-editor.el
+++ b/slack-message-editor.el
@@ -68,7 +68,7 @@
 (defun slack-message-share--send (team room ts msg)
   (let* ((slack-room-list (or (and (object-of-class-p room 'slack-channel)
                                    (slack-message-room-list team))
-                              (list (cons (slack-room-name-with-team-name room)
+                              (list (cons (slack-room-display-name room)
                                           room))))
          (share-channel-id (oref (slack-select-from-list
                                   (slack-room-list

--- a/slack-room.el
+++ b/slack-room.el
@@ -70,7 +70,7 @@
 (defmethod slack-room-buffer-name ((room slack-room))
   (concat "*Slack*"
           " : "
-          (slack-room-name-with-team-name room)))
+          (slack-room-display-name room)))
 
 (defmacro slack-room-with-buffer (room team &rest body)
   (declare (indent 2) (debug t))
@@ -346,7 +346,7 @@
   (cl-labels ((buffer-name (room)
                            (concat "*Slack - Pinned Items*"
                                    " : "
-                                   (slack-room-name-with-team-name room))))
+                                   (slack-room-display-name room))))
     (let* ((messages (mapcar #'(lambda (m) (slack-message-create m team :room room))
                              (mapcar #'(lambda (i)
                                          (plist-get i :message))
@@ -453,7 +453,7 @@
         (setq channels (cl-delete-if #'(lambda (c) (slack-room-equal-p room c))
                                      channels)))
       (message "Channel: %s deleted"
-               (slack-room-name-with-team-name room))))))
+               (slack-room-display-name room))))))
 
 (cl-defun slack-room-request-with-id (url id team success)
   (slack-request

--- a/slack-room.el
+++ b/slack-room.el
@@ -163,23 +163,29 @@
             (setq message (slack-room-find-message room (oref message broadcast-thread-ts)))))
       (and message (oref message thread)))))
 
-(defmethod slack-room-name-with-team-name ((room slack-room))
-  (with-slots (team-id name) room
-    (let ((team (slack-team-find team-id)))
-      (format "%s - %s" (oref team name) name))))
+(defmethod slack-room-team ((room slack-room))
+  (slack-team-find (oref room team-id)))
+
+(defmethod slack-room-display-name ((room slack-room))
+  (let ((room-name (slack-room-name room)))
+    (if slack-display-team-name
+        (format "%s - %s"
+                (oref (slack-room-team room) name)
+                room-name)
+      room-name)))
 
 (defmethod slack-room-label ((room slack-room))
   (format "%s%s%s"
           (if (object-of-class-p room 'slack-im)
               (slack-im-user-presence room)
             "  ")
-          (slack-room-name-with-team-name room)
           (with-slots (unread-count-display) room
             (if (< 0 unread-count-display)
                 (concat " ("
                         (number-to-string unread-count-display)
                         ")")
               ""))))
+          (slack-room-display-name room)
 
 (defmacro slack-room-names (rooms &optional filter)
   `(cl-labels

--- a/slack-room.el
+++ b/slack-room.el
@@ -177,16 +177,19 @@
 (defmethod slack-room-label-prefix ((_room slack-room))
   "  ")
 
+(defmethod slack-room-unread-count-str ((room slack-room))
+  (with-slots (unread-count-display) room
+    (if (< 0 unread-count-display)
+        (concat " ("
+                (number-to-string unread-count-display)
+                ")")
+      "")))
+
 (defmethod slack-room-label ((room slack-room))
   (format "%s%s%s"
-          (with-slots (unread-count-display) room
-            (if (< 0 unread-count-display)
-                (concat " ("
-                        (number-to-string unread-count-display)
-                        ")")
-              ""))))
           (slack-room-label-prefix room)
           (slack-room-display-name room)
+          (slack-room-unread-count-str room)))
 
 (defmacro slack-room-names (rooms &optional filter)
   `(cl-labels

--- a/slack-room.el
+++ b/slack-room.el
@@ -174,17 +174,18 @@
                 room-name)
       room-name)))
 
+(defmethod slack-room-label-prefix ((_room slack-room))
+  "  ")
+
 (defmethod slack-room-label ((room slack-room))
   (format "%s%s%s"
-          (if (object-of-class-p room 'slack-im)
-              (slack-im-user-presence room)
-            "  ")
           (with-slots (unread-count-display) room
             (if (< 0 unread-count-display)
                 (concat " ("
                         (number-to-string unread-count-display)
                         ")")
               ""))))
+          (slack-room-label-prefix room)
           (slack-room-display-name room)
 
 (defmacro slack-room-names (rooms &optional filter)

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -331,14 +331,14 @@
          (room (slack-room-find id team)))
     (oset room is-archived t)
     (message "Channel: %s is archived"
-             (slack-room-name-with-team-name room))))
+             (slack-room-display-name room))))
 
 (defun slack-ws-handle-room-unarchive (payload team)
   (let* ((id (plist-get payload :channel))
          (room (slack-room-find id team)))
     (oset room is-archived nil)
     (message "Channel: %s is unarchived"
-             (slack-room-name-with-team-name room))))
+             (slack-room-display-name room))))
 
 (defun slack-ws-handle-channel-deleted (payload team)
   (let ((id (plist-get payload :channel)))
@@ -368,13 +368,13 @@
               (setq channels
                     (replace-room channel channels)))
             (message "Joined channel %s"
-                     (slack-room-name-with-team-name channel)))
+                     (slack-room-display-name channel)))
         (let ((group (slack-room-create c team 'slack-group)))
           (with-slots (groups) team
             (setq groups
                   (replace-room group groups)))
           (message "Joined group %s"
-                   (slack-room-name-with-team-name group)))))))
+                   (slack-room-display-name group)))))))
 
 (defun slack-ws-handle-presence-change (payload team)
   (let* ((id (plist-get payload :user))

--- a/slack.el
+++ b/slack.el
@@ -93,6 +93,10 @@ never means never show typing indicator."
                  (const buffer)
                  (const never)))
 
+(defcustom slack-display-team-name t
+  "If nil, only display channel, im, group name."
+  :group 'slack)
+
 (defconst slack-oauth2-authorize "https://slack.com/oauth/authorize")
 (defconst slack-oauth2-access "https://slack.com/api/oauth.access")
 (defconst slack-authorize-url "https://slack.com/api/rtm.start")


### PR DESCRIPTION
ref. #166 
- add `slack-display-team-name` default value is `t`