### PR TITLE
add modeline unread count

### DIFF
--- a/slack-message-notification.el
+++ b/slack-message-notification.el
@@ -118,11 +118,14 @@
   (add-to-list 'global-mode-string '(:eval slack-modeline) t))
 
 (defun slack-update-modeline ()
-  (setq slack-modeline
-        (funcall slack-modeline-formatter
-                 (mapcar #'(lambda (e) (cons (or (oref e modeline-name) (slack-team-name e))
-                                             (slack-team-get-unread-messages e)))
-                         (cl-remove-if-not #'slack-team-modeline-enabledp slack-teams)))))
+  (let ((teams (cl-remove-if-not #'slack-team-modeline-enabledp slack-teams)))
+    (when (< 0 (length teams))
+      (setq slack-modeline
+            (funcall slack-modeline-formatter
+                     (mapcar #'(lambda (e) (cons (or (oref e modeline-name) (slack-team-name e))
+                                                 (slack-team-get-unread-messages e)))
+                             teams)))
+      (force-mode-line-update))))
 
 (provide 'slack-message-notification)
 ;;; slack-message-notification.el ends here

--- a/slack-message-notification.el
+++ b/slack-message-notification.el
@@ -60,6 +60,8 @@
   :type '(choice file (const :tag "Stock alert icon" nil))
   :group 'slack)
 
+(defvar slack-modeline nil)
+
 (defcustom slack-modeline-formatter #'slack-default-modeline-formatter
   "Format modeline with Arg '((team-name . unread-count))."
   :group 'slack)
@@ -111,6 +113,16 @@
       (format "[ %s: %s ]" (caar alist) (cdar alist))
     (mapconcat #'(lambda (e) (format "[ %s: %s ]" (car e) (cdr e)))
                alist " ")))
+
+(defun slack-enable-modeline ()
+  (add-to-list 'global-mode-string '(:eval slack-modeline) t))
+
+(defun slack-update-modeline ()
+  (setq slack-modeline
+        (funcall slack-modeline-formatter
+                 (mapcar #'(lambda (e) (cons (or (oref e modeline-name) (slack-team-name e))
+                                             (slack-team-get-unread-messages e)))
+                         (cl-remove-if-not #'slack-team-modeline-enabledp slack-teams)))))
 
 (provide 'slack-message-notification)
 ;;; slack-message-notification.el ends here

--- a/slack-message-notification.el
+++ b/slack-message-notification.el
@@ -60,6 +60,10 @@
   :type '(choice file (const :tag "Stock alert icon" nil))
   :group 'slack)
 
+(defcustom slack-modeline-formatter #'slack-default-modeline-formatter
+  "Format modeline with Arg '((team-name . unread-count))."
+  :group 'slack)
+
 (defun slack-message-notify (message room team)
   (if slack-message-custom-notifier
       (funcall slack-message-custom-notifier message room team)
@@ -100,6 +104,13 @@
       (with-slots (self-id) team
         (slack-message-sender-equalp m self-id))
     (slack-message-sender-equalp m (oref team self-id))))
+
+(defun slack-default-modeline-formatter (alist)
+  "Arg is alist of '((team-name . unread-count))"
+  (if (= 1 (length alist))
+      (format "[ %s: %s ]" (caar alist) (cdar alist))
+    (mapconcat #'(lambda (e) (format "[ %s: %s ]" (car e) (cdr e)))
+               alist " ")))
 
 (provide 'slack-message-notification)
 ;;; slack-message-notification.el ends here

--- a/slack-message-update.el
+++ b/slack-message-update.el
@@ -77,7 +77,8 @@
                                  :notify (not no-notify))))
       (slack-message-update--room update)
       (slack-message-update--buffer update)
-      (slack-message-update--notify update))))
+      (slack-message-update--notify update)
+      (slack-update-modeline))))
 
 (provide 'slack-message-update)
 ;;; slack-message-update.el ends here

--- a/slack-team.el
+++ b/slack-team.el
@@ -83,7 +83,8 @@ use `slack-change-current-team' to change `slack-current-team'"
    (reminders :initform nil :type list)
    (ping-check-timers)
    (threads :type slack-team-threads :initform (make-instance 'slack-team-threads))
-   (modeline-enabled :initarg :modeline-enabled :initform nil)))
+   (modeline-enabled :initarg :modeline-enabled :initform nil)
+   (modeline-name :initarg :modeline-name :initform nil)))
 
 (defun slack-team-find (id)
   (cl-find-if #'(lambda (team) (string= id (oref team id)))

--- a/slack-team.el
+++ b/slack-team.el
@@ -33,6 +33,10 @@
 use `slack-change-current-team' to change `slack-current-team'"
   :group 'slack)
 
+(defcustom slack-modeline-count-only-subscribed-channel t
+  "Count unread only subscribed channel."
+  :group 'slack)
+
 (defclass slack-team-threads ()
   ((initializedp :initform nil)
    (has-more :initform t)
@@ -220,8 +224,20 @@ you can change current-team with `slack-change-current-team'"
   (with-slots (token) team
     (or (not token) (< (length token) 1))))
 
+(defun slack-team-get-unread-messages (team)
+  (cl-labels
+      ((count-unread (rooms)
+                     (cl-reduce #'(lambda (a e) (+ a (oref e unread-count-display)))
+                                rooms :initial-value 0)))
+    (with-slots (ims channels groups) team
+      (let ((rooms (append ims channels groups)))
+        (+ (count-unread (if slack-modeline-count-only-subscribed-channel
+                             (cl-remove-if-not #'(lambda (e) (slack-room-subscribedp e team))
+                                               rooms)
+                           rooms)))))))
 
 (defun slack-team-modeline-enabledp (team)
   (oref team modeline-enabled))
+
 (provide 'slack-team)
 ;;; slack-team.el ends here

--- a/slack-team.el
+++ b/slack-team.el
@@ -78,7 +78,8 @@ use `slack-change-current-team' to change `slack-current-team'"
    (typing-timer :initform nil)
    (reminders :initform nil :type list)
    (ping-check-timers)
-   (threads :type slack-team-threads :initform (make-instance 'slack-team-threads))))
+   (threads :type slack-team-threads :initform (make-instance 'slack-team-threads))
+   (modeline-enabled :initarg :modeline-enabled :initform nil)))
 
 (defun slack-team-find (id)
   (cl-find-if #'(lambda (team) (string= id (oref team id)))
@@ -219,5 +220,8 @@ you can change current-team with `slack-change-current-team'"
   (with-slots (token) team
     (or (not token) (< (length token) 1))))
 
+
+(defun slack-team-modeline-enabledp (team)
+  (oref team modeline-enabled))
 (provide 'slack-team)
 ;;; slack-team.el ends here

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -507,7 +507,8 @@
         (new-unread-count-display (plist-get payload :unread_count_display)))
     (when room
       (with-slots (unread-count-display) room
-        (setq unread-count-display new-unread-count-display)))))
+        (setq unread-count-display new-unread-count-display))
+      (slack-update-modeline))))
 
 (defun slack-ws-handle-file-comment-added (payload team)
   (let* ((file-id (plist-get payload :file_id))

--- a/slack.el
+++ b/slack.el
@@ -157,6 +157,7 @@ never means never show typing indicator."
       (oset team bots (append (plist-get data :bots) nil))
       (oset team ws-url (plist-get data :url))
       (oset team connected t)
+      (slack-update-modeline)
       team)))
 
 (cl-defun slack-on-authorize (data team)

--- a/slack.el
+++ b/slack.el
@@ -210,7 +210,9 @@ never means never show typing indicator."
       (if slack-teams
           (cl-loop for team in slack-teams
                    do (start team))
-        (slack-start (call-interactively #'slack-register-team))))))
+        (slack-start (call-interactively #'slack-register-team))))
+    (slack-enable-modeline)))
+
 
 (provide 'slack)
 ;;; slack.el ends here


### PR DESCRIPTION
close #177 

add custom variables
- `slack-modeline-formatter` 
  - function takes argument like `'((team-name . unread-count) ... )`
- `slack-modeline-count-only-subscribed-channel`
  - default `t`. if `nil` count all channel's unread-count.

add team configurations
- `modeline-enabled`
  - default `nil`. set this `t` if you want to show unread-count at modeline.
- `modeline-name`
  - default `nil` name displayed at modeline. if nil, use team name from slack server.