### PR TITLE
Profile image

### DIFF
--- a/slack-bot-message.el
+++ b/slack-bot-message.el
@@ -27,6 +27,7 @@
 (require 'eieio)
 (require 'slack-message)
 (require 'slack-message-formatter)
+(require 'slack-util)
 
 (defun slack-find-bot (id team)
   (with-slots (bots) team
@@ -70,7 +71,7 @@
 
 (defun slack-bot-fetch-image (bot size team)
   (let* ((image-url (slack-bot-image-url bot size))
-         (file-path (and image-url (slack-user-image-path image-url team))))
+         (file-path (and image-url (slack-profile-image-path image-url team))))
     (when file-path
       (if (file-exists-p file-path) file-path
         (url-copy-file image-url file-path))

--- a/slack-bot-message.el
+++ b/slack-bot-message.el
@@ -82,5 +82,9 @@
       (when image
         (create-image image nil nil :ascent 100)))))
 
+(defmethod slack-message-profile-image ((m slack-bot-message) team)
+  (let ((bot (slack-find-bot (slack-message-sender-id m) team)))
+    (slack-bot-image bot team)))
+
 (provide 'slack-bot-message)
 ;;; slack-bot-message.el ends here

--- a/slack-bot-message.el
+++ b/slack-bot-message.el
@@ -60,5 +60,27 @@
 (defmethod slack-attachment-to-alert ((a slack-attachment))
   (oref a fallback))
 
+(defun slack-bot-image-url (bot size)
+  (let ((icons (plist-get bot :icons)))
+    (cond
+     ((eq size 36) (plist-get icons :image_36))
+     ((eq size 48) (plist-get icons :image_48))
+     ((eq size 72) (plist-get icons :image_72))
+     (t (plist-get icons :image_36)))))
+
+(defun slack-bot-fetch-image (bot size team)
+  (let* ((image-url (slack-bot-image-url bot size))
+         (file-path (and image-url (slack-user-image-path image-url team))))
+    (when file-path
+      (if (file-exists-p file-path) file-path
+        (url-copy-file image-url file-path))
+      file-path)))
+
+(cl-defun slack-bot-image (bot team &optional (size 36))
+  (when bot
+    (let ((image (slack-bot-fetch-image bot size team)))
+      (when image
+        (create-image image nil nil :ascent 100)))))
+
 (provide 'slack-bot-message)
 ;;; slack-bot-message.el ends here

--- a/slack-file.el
+++ b/slack-file.el
@@ -203,17 +203,13 @@
   (interactive)
   (let* ((team (slack-team-select))
          (room (slack-file-room-obj team)))
-    (with-slots (messages) room
-      (if messages
+    (with-slots (buffer) room
+      (if buffer
           (slack-file-create-buffer team)
         (slack-room-history-request room team)
         (slack-file-create-buffer team)))))
 
-(defmethod slack-room-history ((room slack-file-room) team
-                               &optional
-                               oldest
-                               after-success
-                               async)
+(cl-defmethod slack-room-history-request ((room slack-file-room) team &key oldest after-success async)
   (cl-labels
       ((on-file-list
         (&key data &allow-other-keys)

--- a/slack-file.el
+++ b/slack-file.el
@@ -168,8 +168,10 @@
 (defmethod slack-message-to-string ((file slack-file) team)
   (with-slots (ts name size filetype permalink user initial-comment reactions comments comments-count)
       file
-    (let* ((header (slack-message-put-header-property
-                    (slack-user-name user team)))
+    (let* ((header (let ((header (slack-message-put-header-property (slack-user-name user team))))
+                     (if (slack-team-display-profile-image team)
+                         (slack-message-header-with-image file header team)
+                       header)))
            (body (slack-message-put-text-property
                   (format "name: %s\nsize: %s\ntype: %s\n%s\n"
                           name size filetype permalink)))

--- a/slack-message-formatter.el
+++ b/slack-message-formatter.el
@@ -118,15 +118,19 @@
 (defmethod slack-message-profile-image ((m slack-message) team)
   (slack-user-image (slack-user-find (slack-message-sender-id m) team) team))
 
+(defmethod slack-message-header-with-image ((m slack-message) header team)
+  (let ((image (slack-message-profile-image m team)))
+    (if image
+        (format "%s %s" (propertize "image" 'display image) header)
+      header)))
+
 (defmethod slack-message-to-string ((m slack-message) team)
   (let ((text (if (slot-boundp m 'text)
                   (oref m text))))
-    (let* ((image (and (slack-team-display-profile-image team)
-                       (slack-message-profile-image m team)))
-           (header (let ((h (slack-message-put-header-property
-                             (slack-message-header m team))))
-                     (if image (format "%s %s" (propertize "image" 'display image) h)
-                       h)))
+    (let* ((header (let ((header (slack-message-put-header-property (slack-message-header m team))))
+                     (if (slack-team-display-profile-image team)
+                         (slack-message-header-with-image m header team)
+                       header)))
            (row-body (slack-message-body m team))
            (attachment-body (slack-message-attachment-body m team))
            (body (if (oref m deleted-at)

--- a/slack-message-formatter.el
+++ b/slack-message-formatter.el
@@ -115,11 +115,18 @@
                        "\n")
             "\n")))
 
+(defmethod slack-message-profile-image ((m slack-message) team)
+  (slack-user-image (slack-user-find (slack-message-sender-id m) team) team))
+
 (defmethod slack-message-to-string ((m slack-message) team)
   (let ((text (if (slot-boundp m 'text)
                   (oref m text))))
-    (let* ((header (slack-message-put-header-property
-                    (slack-message-header m team)))
+    (let* ((image (and (slack-team-display-profile-image team)
+                       (slack-message-profile-image m team)))
+           (header (let ((h (slack-message-put-header-property
+                             (slack-message-header m team))))
+                     (if image (format "%s %s" (propertize "image" 'display image) h)
+                       h)))
            (row-body (slack-message-body m team))
            (attachment-body (slack-message-attachment-body m team))
            (body (if (oref m deleted-at)

--- a/slack-team.el
+++ b/slack-team.el
@@ -86,6 +86,7 @@ use `slack-change-current-team' to change `slack-current-team'"
    (modeline-enabled :initarg :modeline-enabled :initform nil)
    (modeline-name :initarg :modeline-name :initform nil)
    (websocket-event-log-enabled :initarg :websocket-event-log-enabled :initform nil)
+   (display-profile-image :initarg :display-profile-image :initform nil)
    ))
 
 (defun slack-team-find (id)
@@ -244,6 +245,9 @@ you can change current-team with `slack-change-current-team'"
 
 (defmethod slack-team-event-log-enabledp ((team slack-team))
   (oref team websocket-event-log-enabled))
+
+(defmethod slack-team-display-profile-image ((team slack-team))
+  (oref team display-profile-image))
 
 (provide 'slack-team)
 ;;; slack-team.el ends here

--- a/slack-user.el
+++ b/slack-user.el
@@ -24,6 +24,7 @@
 
 ;;; Code:
 
+(require 'slack-util)
 (require 'slack-request)
 (require 'slack-room)
 
@@ -297,16 +298,9 @@
    ((eq size 72) (slack-user-image-url-72 user))
    (t (slack-user-image-url-32 user))))
 
-(defun slack-user-image-path (image-url team)
-  (expand-file-name
-   (concat (md5 (concat (slack-team-name team) "-" image-url))
-           "."
-           (file-name-extension image-url))
-   temporary-file-directory))
-
 (defun slack-user-fetch-image (user size team)
   (let* ((image-url (slack-user-image-url user size))
-         (file-path (and image-url (slack-user-image-path image-url team))))
+         (file-path (and image-url (slack-profile-image-path image-url team))))
     (when file-path
       (if (file-exists-p file-path) file-path
         (url-copy-file image-url file-path)))

--- a/slack-util.el
+++ b/slack-util.el
@@ -26,6 +26,10 @@
 
 (require 'eieio)
 
+(defcustom slack-profile-image-file-directory temporary-file-directory
+  "Default directory for slack profile images."
+  :group 'slack)
+
 (defun slack-seq-to-list (seq)
   (if (listp seq) seq (append seq nil)))
 
@@ -127,6 +131,13 @@
     (if buf
         (funcall slack-buffer-function buf)
       (error "No Event Log Buffer"))))
+
+(defun slack-profile-image-path (image-url team)
+  (expand-file-name
+   (concat (md5 (concat (slack-team-name team) "-" image-url))
+           "."
+           (file-name-extension image-url))
+   slack-profile-image-file-directory))
 
 (provide 'slack-util)
 ;;; slack-util.el ends here


### PR DESCRIPTION
display profile image

- `slack-profile-image-file-directory`
  - default: `temporary-file-directory`
  - if you want profile image persisted, set some directory.
- `display-profile-image`
  - default: `nil`
  - this variable scope is team. set `t` to display image.

```
(slack-register-team
   :default t
   :name  "aaaaa"
   .....
   :display-profile-image t)
```