### PR TITLE
Hide deleted users

### DIFF
--- a/slack-util.el
+++ b/slack-util.el
@@ -112,8 +112,9 @@
                     (cl-case (prefix-type arg)
                       (user
                        (cl-loop for user in (oref slack-current-team users)
-                                if (string-prefix-p content
-                                                    (plist-get user :name))
+                                if (and (not (eq (plist-get user :deleted) t))
+                                        (string-prefix-p content
+                                                         (plist-get user :name)))
                                 collect (concat "@" (plist-get user :name))))
                       (channel
                        (cl-loop for team in (oref slack-current-team channels)


### PR DESCRIPTION
Right now company-mode completion will display deleted users; this patch hides them.