### PR TITLE
Update websocket library to version 1.8

### DIFF
--- a/slack-pkg.el
+++ b/slack-pkg.el
@@ -1,6 +1,6 @@
 (define-package "slack" "0"
   "Slack client for Emacs"
-  '((websocket "1.5")
+  '((websocket "1.8")
     (request "0.2.0")
     (oauth2 "0.10")
     (circe "2.2")

--- a/slack.el
+++ b/slack.el
@@ -5,7 +5,7 @@
 ;; Author: yuya.minami <yuya.minami@yuyaminami-no-MacBook-Pro.local>
 ;; Keywords: tools
 ;; Version: 0.0.2
-;; Package-Requires: ((websocket "1.5") (request "0.2.0") (oauth2 "0.10") (circe "2.3") (alert "1.2") (emojify "0.4") (emacs "24.4"))
+;; Package-Requires: ((websocket "1.8") (request "0.2.0") (oauth2 "0.10") (circe "2.3") (alert "1.2") (emojify "0.4") (emacs "24.4"))
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or


### PR DESCRIPTION
In older version `websocket-open` does not accept `:nowait` arg.