### PR TITLE
Fix for slack-mapconcat-images sorting issue.

### DIFF
--- a/slack-util.el
+++ b/slack-util.el
@@ -234,7 +234,8 @@
 (defun slack-mapconcat-images (images)
   (when images
     (cl-labels ((sort-images (images)
-                             (let ((compare (if (< emacs-major-version 26)
+                             (let ((compare (if (or (and (eq system-type 'darwin) (< emacs-major-version 26))
+						    (< emacs-major-version 25))
                                                 #'>
                                               #'<)))
                                (cl-sort images compare :key #'(lambda (image) (caddr (car image))))))


### PR DESCRIPTION
This fixes this issue: https://github.com/yuya373/emacs-slack/issues/229

In this fix: the sorting of the concated images are now different depending on the system-type.