### PR TITLE
Prefer the bot name provided in the message

### DIFF
--- a/slack-bot-message.el
+++ b/slack-bot-message.el
@@ -36,7 +36,8 @@
                 bots)))
 
 (defmethod slack-bot-name ((m slack-bot-message) team)
-  (or (oref m username)
+  (or (unless (slack-string-blankp (oref m username))
+        (oref m username))
       (when (slot-boundp m 'bot-id)
         (let ((bot (slack-find-bot (oref m bot-id) team)))
           (plist-get bot :name)))

--- a/slack-bot-message.el
+++ b/slack-bot-message.el
@@ -36,12 +36,11 @@
                 bots)))
 
 (defmethod slack-bot-name ((m slack-bot-message) team)
-  (if (slot-boundp m 'bot-id)
-      (let ((bot (slack-find-bot (oref m bot-id) team)))
-        (if bot
-            (plist-get bot :name)
-          (oref m username)))
-    (oref m username)))
+  (or (oref m username)
+      (when (slot-boundp m 'bot-id)
+        (let ((bot (slack-find-bot (oref m bot-id) team)))
+          (plist-get bot :name)))
+      "Unknown Bot"))
 
 (defmethod slack-message-to-alert ((m slack-bot-message) team)
   (let ((text (if (slot-boundp m 'text)


### PR DESCRIPTION
This looks for a bot username in `m` before using the default name for
that bot. In my experience, that better reflects the behaviour of the
web app.