### PR TITLE
Fix unbound function in file-upload

### DIFF
--- a/slack-file.el
+++ b/slack-file.el
@@ -283,7 +283,7 @@
                                                          (cons "" channels) nil t)
                                                  (list "Select channel: " channels nil t)))))
                           (if (< 0 (length selected))
-                              (select-channels (remove-if (lambda (x) (equal selected (car-safe x))) channels)
+                              (select-channels (cl-remove-if (lambda (x) (equal selected (car-safe x))) channels)
                                                (cons selected acc))
                             acc)))
        (channel-id (selected channels)


### PR DESCRIPTION
All other usages in the package use `cl-remove-if'. This one must have slipped by somehow.