### PR TITLE
Use token instead of client-id to check equalp of teams

### DIFF
--- a/slack-team.el
+++ b/slack-team.el
@@ -103,8 +103,8 @@ use `slack-change-current-team' to change `slack-current-team'"
   (slack-ws-close team))
 
 (defmethod slack-team-equalp ((team slack-team) other)
-  (with-slots (client-id) team
-    (string= client-id (oref other client-id))))
+  (with-slots (token) team
+    (string= token (oref other token))))
 
 (defmethod slack-team-name ((team slack-team))
   (oref team name))


### PR DESCRIPTION
https://api.slack.com/docs/oauth

I wondered why I could not register multiple teams. There is no need to register a
client-id for each team.

The client-id is used to identify/auth apps (like Emacs in this case)
not teams. So it can be used for multiple teams.