### PR TITLE
map RET to slack-thread-show-or-create

### DIFF
--- a/slack-thread.el
+++ b/slack-thread.el
@@ -206,7 +206,7 @@
           (propertize text
                       'face '(:underline t)
                       'keymap (let ((map (make-sparse-keymap)))
-                                (define-key map (kbd "RET") #'slack-thread-show-messages)
+                                (define-key map (kbd "RET") #'slack-thread-show-or-create)
                                 map)))
       "")))
 


### PR DESCRIPTION
Fixes error:
  "command-execute: Wrong type argument: commandp, slack-thread-show-messages"