### PR TITLE
fix typo `wight` to `weight`

### DIFF
--- a/slack-buffer.el
+++ b/slack-buffer.el
@@ -147,7 +147,7 @@
 
 (defmethod slack-buffer-insert-load-more ((this slack-buffer))
   (let ((str (propertize "(load more)\n"
-                         'face '(:underline t :wight bold)
+                         'face '(:underline t :weight bold)
                          'keymap (let ((map (make-sparse-keymap)))
                                    (define-key map (kbd "RET")
                                      #'(lambda ()


### PR DESCRIPTION
I was getting this warning:

```
user-error: No more buttonsInvalid face attribute :wight bold
Invalid face attribute :wight bold [39 times]
```

Here's the fix.