### PR TITLE
add full-and-display-names

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Emacs client for [Slack](https://slack.com/)
    :client-id "aaaaaaaaaaa.00000000000"
    :client-secret "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
    :token "aaaa-sssssssssss-88888888888-hhhhhhhhhhh-jjjjjjjjjj"
-   :subscribed-channels '(test-rename rrrrr))
+   :subscribed-channels '(test-rename rrrrr)
+   :full-and-display-names t
+   )
 
   (slack-register-team
    :name "test"

--- a/slack-im.el
+++ b/slack-im.el
@@ -42,7 +42,8 @@
 
 (defclass slack-im (slack-room)
   ((user :initarg :user :initform "")
-   (is-open :initarg :is_open :initform t)))
+   (is-open :initarg :is_open :initform t)
+   (is-user-deleted :initarg :is_user_deleted :initform nil)))
 
 (defmethod slack-merge ((this slack-im) other)
   (call-next-method)
@@ -51,7 +52,8 @@
     (setq is-open (oref other is-open))))
 
 (defmethod slack-room-open-p ((room slack-im))
-  (oref room is-open))
+  (oref room is-open)
+  (not (oref room is-user-deleted)))
 
 (defmethod slack-im-user-presence ((room slack-im))
   (with-slots (team-id) room

--- a/slack-message-formatter.el
+++ b/slack-message-formatter.el
@@ -212,7 +212,8 @@
                  (text)
                  (concat "@" (or
                               (slack-message-replace-user-name text)
-                              (slack-user-name (match-string 1 text) team)
+                              (let ((user (slack-user--find (match-string 1 text) team)))
+                                (plist-get user :name))
                               (match-string 1 text)))))
       (replace-regexp-in-string user-regexp
                                 #'unescape-user-id

--- a/slack-team.el
+++ b/slack-team.el
@@ -109,6 +109,7 @@ use `slack-change-current-team' to change `slack-current-team'"
    (slack-search-result-buffer :initform nil :type (or null list))
    (slack-file-comment-compose-buffer :initform nil :type (or null list))
    (reconnect-url :initform "" :type string)
+   (name-display-style :initarg :name-display-style :initform 'display-name)
    ))
 
 (cl-defmethod slack-team-kill-buffers ((this slack-team) &key (except nil))

--- a/slack-team.el
+++ b/slack-team.el
@@ -109,7 +109,7 @@ use `slack-change-current-team' to change `slack-current-team'"
    (slack-search-result-buffer :initform nil :type (or null list))
    (slack-file-comment-compose-buffer :initform nil :type (or null list))
    (reconnect-url :initform "" :type string)
-   (name-display-style :initarg :name-display-style :initform 'display-name)
+   (full-and-display-names :initarg :full-and-display-names :initform nil)
    ))
 
 (cl-defmethod slack-team-kill-buffers ((this slack-team) &key (except nil))

--- a/slack-user.el
+++ b/slack-user.el
@@ -57,11 +57,11 @@
         (plist-get user :id))))
 
 (defun slack-user-name (id team)
-  (let ((user (slack-user--find id team)))
-    (if user
-        (if (eq (oref team name-display-style) 'full-and-display-name)
-            (plist-get user :real_name)
-          (plist-get user :name)))))
+  (slack-if-let* ((user (slack-user--find id team))
+                  (profile (slack-user-profile user)))
+      (if (eq (oref team name-display-style) 'full-and-display-name)
+          (plist-get profile :real_name_normalized)
+        (plist-get user :display_name_normalized))))
 
 (defun slack-user-status (id team)
   (let* ((user (slack-user--find id team))

--- a/slack-user.el
+++ b/slack-user.el
@@ -59,7 +59,7 @@
 (defun slack-user-name (id team)
   (slack-if-let* ((user (slack-user--find id team))
                   (profile (slack-user-profile user)))
-      (if (eq (oref team name-display-style) 'full-and-display-name)
+      (if (oref team full-and-display-names)
           (plist-get profile :real_name_normalized)
         (plist-get user :display_name_normalized))))
 

--- a/slack-user.el
+++ b/slack-user.el
@@ -59,7 +59,9 @@
 (defun slack-user-name (id team)
   (let ((user (slack-user--find id team)))
     (if user
-        (plist-get user :name))))
+        (if (eq (oref team name-display-style) 'full-and-display-name)
+            (plist-get user :real_name)
+          (plist-get user :name)))))
 
 (defun slack-user-status (id team)
   (let* ((user (slack-user--find id team))


### PR DESCRIPTION
close #258 

add `full-and-display-names` to team property. default `nil`.
nil means Just display names.

[![Screenshot from Gyazo](https://gyazo.com/2c61460546dd14344c93ef114c6309b9/raw)](https://gyazo.com/2c61460546dd14344c93ef114c6309b9)
