### PR TITLE
Request worker

### DIFF
--- a/slack-channel.el
+++ b/slack-channel.el
@@ -93,10 +93,8 @@
                   (if after-success
                       (funcall after-success team))
                   (mapc #'(lambda (room)
-                            (slack-request-retry-request
-                             (slack-room-create-info-request room team)
-                             1
-                             team))
+                            (slack-request-worker-push
+                             (slack-room-create-info-request room team)))
                         (oref team channels))
                   (slack-log "Slack Channel List Updated" team))))
       (slack-room-list-update slack-channel-list-url

--- a/slack-channel.el
+++ b/slack-channel.el
@@ -93,7 +93,10 @@
                   (if after-success
                       (funcall after-success team))
                   (mapc #'(lambda (room)
-                            (slack-room-info-request room team))
+                            (slack-request-retry-request
+                             (slack-room-create-info-request room team)
+                             1
+                             team))
                         (oref team channels))
                   (slack-log "Slack Channel List Updated" team))))
       (slack-room-list-update slack-channel-list-url

--- a/slack-channel.el
+++ b/slack-channel.el
@@ -96,7 +96,7 @@
                             (slack-request-worker-push
                              (slack-room-create-info-request room team)))
                         (oref team channels))
-                  (slack-log "Slack Channel List Updated" team))))
+                  (slack-log "Slack Channel List Updated" team :level 'info))))
       (slack-room-list-update slack-channel-list-url
                               #'on-list-update
                               team

--- a/slack-group.el
+++ b/slack-group.el
@@ -107,7 +107,7 @@
                   (mapc #'(lambda (room)
                             (slack-room-info-request room team))
                         (oref team groups))
-                  (slack-log "Slack Group List Updated" team))))
+                  (slack-log "Slack Group List Updated" team :level 'info))))
       (slack-room-list-update slack-group-list-url
                               #'on-list-update
                               team

--- a/slack-im.el
+++ b/slack-im.el
@@ -135,7 +135,7 @@
                 (mapc #'(lambda (room)
                           (slack-room-info-request room team))
                       (oref team ims))
-                (slack-log "Slack Im List Updated" team))))
+                (slack-log "Slack Im List Updated" team :level 'info))))
     (slack-room-list-update slack-im-list-url
                             #'on-update-room-list
                             team

--- a/slack-request-worker.el
+++ b/slack-request-worker.el
@@ -27,6 +27,7 @@
 (require 'eieio)
 (require 'slack-util)
 (require 'slack-request)
+(require 'slack-team)
 
 (defcustom slack-request-worker-max-request-limit 30
   "Max request count perform simultaneously."
@@ -106,6 +107,15 @@
              (timerp (oref slack-request-worker-instance timer)))
     (cancel-timer (oref slack-request-worker-instance timer)))
   (setq slack-request-worker-instance nil))
+
+(defmethod slack-request-worker-remove-request ((team slack-team))
+  "Remove request from TEAM in queue."
+  (when slack-request-worker-instance
+    (oset slack-request-worker-instance
+          queue
+          (cl-remove-if #'(lambda (req) (string= (oref (oref req team) id)
+                                                 (oref team id)))
+                        (oref slack-request-worker-instance queue)))))
 
 (provide 'slack-request-worker)
 ;;; slack-request-worker.el ends here

--- a/slack-request-worker.el
+++ b/slack-request-worker.el
@@ -128,7 +128,8 @@
           (push req new-queue)))
 
       (dolist (req to-remove)
-        (when (not (request-response-done-p (oref req response)))
+        (when (and (oref req response)
+                   (not (request-response-done-p (oref req response))))
           (request-abort (oref req response))))
 
       (oset slack-request-worker-instance queue new-queue)

--- a/slack-request-worker.el
+++ b/slack-request-worker.el
@@ -1,0 +1,104 @@
+;;; slack-request-worker.el ---                      -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2018  南優也
+
+;; Author: 南優也 <yuyaminami@minamiyuuya-no-MacBook.local>
+;; Keywords:
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+
+(require 'eieio)
+(require 'slack-util)
+(require 'slack-request)
+
+(defcustom slack-request-worker-max-request-limit 30
+  "Max request count perform simultaneously."
+  :group 'slack)
+
+(defvar slack-request-worker-instance nil)
+
+(defclass slack-request-worker ()
+  ((queue :initform '() :type list)
+   (timer :initform nil)
+   (current-request-count :initform 0 :type integer)
+   ))
+
+(defun slack-request-worker-create ()
+  "Create `slack-request-worker' instance."
+  (make-instance 'slack-request-worker))
+
+(defmethod slack-request-worker-push ((this slack-request-worker) req)
+  (let ((l '()))
+    (cl-pushnew req (oref this queue)
+                :test #'slack-equalp)))
+
+(defmethod slack-request-worker-create-timer ((_this slack-request-worker))
+  (run-at-time t 1 #'slack-request-worker-execute))
+
+(defun slack-request-worker-execute ()
+  "Pop request from queue until `slack-request-worker-max-request-limit', and execute."
+  (let ((do '())
+        (skip '())
+        (current (time-to-seconds))
+        (limit (- slack-request-worker-max-request-limit
+                  (oref slack-request-worker-instance
+                        current-request-count))))
+
+    (cl-loop for req in (reverse (oref slack-request-worker-instance queue))
+             do (if (and (< (oref req execute-at) current)
+                         (< (length do) limit))
+                    (push req do)
+                  (push req skip)))
+
+    ;; (message "[WORKER] QUEUE: %s, LIMIT: %s, CURRENT: %s, DO: %s, SKIP: %s"
+    ;;          (length (oref slack-request-worker-instance queue))
+    ;;          slack-request-worker-max-request-limit
+    ;;          (oref slack-request-worker-instance current-request-count)
+    ;;          (length do)
+    ;;          (length skip))
+
+    (oset slack-request-worker-instance queue skip)
+
+    (cl-labels
+        ((decl-request-count
+          ()
+          (cl-decf (oref slack-request-worker-instance
+                         current-request-count))))
+      (cl-loop for req in do
+               do (progn
+                    (cl-incf (oref slack-request-worker-instance
+                                   current-request-count))
+                    (slack-request req
+                                   :on-success #'decl-request-count
+                                   :on-error #'decl-request-count
+                                   ))))))
+
+(defmethod slack-request-worker-push ((req slack-request-request))
+  (unless slack-request-worker-instance
+    (setq slack-request-worker-instance
+          (slack-request-worker-create)))
+  (slack-request-worker-push slack-request-worker-instance req)
+  (unless (oref slack-request-worker-instance timer)
+    (oset slack-request-worker-instance timer
+          (slack-request-worker-create-timer slack-request-worker-instance))))
+
+
+(provide 'slack-request-worker)
+;;; slack-request-worker.el ends here

--- a/slack-request-worker.el
+++ b/slack-request-worker.el
@@ -99,6 +99,12 @@
     (oset slack-request-worker-instance timer
           (slack-request-worker-create-timer slack-request-worker-instance))))
 
+(defun slack-request-worker-quit ()
+  "Cancel timer and remove `slack-request-worker-instance'."
+  (when (and slack-request-worker-instance
+             (timerp (oref slack-request-worker-instance timer)))
+    (cancel-timer (oref slack-request-worker-instance timer)))
+  (setq slack-request-worker-instance nil))
 
 (provide 'slack-request-worker)
 ;;; slack-request-worker.el ends here

--- a/slack-request-worker.el
+++ b/slack-request-worker.el
@@ -127,6 +127,10 @@
             (push req to-remove)
           (push req new-queue)))
 
+      (dolist (req to-remove)
+        (when (not (request-response-done-p (oref req response)))
+          (request-abort (oref req response))))
+
       (oset slack-request-worker-instance queue new-queue)
       (slack-log (format "Remove Request from Worker, ALL: %s, REMOVED: %s, NEW-QUEUE: %s"
                          (length all)

--- a/slack-request.el
+++ b/slack-request.el
@@ -46,7 +46,8 @@
       (json-end-of-file nil))))
 
 (defclass slack-request-request ()
-  ((url :initarg :url)
+  ((response :initform nil)
+   (url :initarg :url)
    (team :initarg :team)
    (type :initarg :type :initform "GET")
    (success :initarg :success)
@@ -130,19 +131,20 @@
                                   :data data))
                        (when (functionp on-error)
                          (funcall on-error)))))
-        (request
-         url
-         :type type
-         :sync sync
-         :params (cons (cons "token" (oref team token))
-                       params)
-         :data data
-         :files files
-         :headers headers
-         :parser parser
-         :success #'on-success
-         :error #'on-error
-         :timeout timeout)))))
+        (oset req response
+              (request
+               url
+               :type type
+               :sync sync
+               :params (cons (cons "token" (oref team token))
+                             params)
+               :data data
+               :files files
+               :headers headers
+               :parser parser
+               :success #'on-success
+               :error #'on-error
+               :timeout timeout))))))
 
 
 (cl-defmacro slack-request-handle-error ((data req-name &optional handler) &body body)

--- a/slack-request.el
+++ b/slack-request.el
@@ -76,10 +76,6 @@
           args)
     (apply #'make-instance 'slack-request-request ret)))
 
-(defmethod slack-request-suspend-request ((req slack-request-request))
-  (with-slots (team) req
-    (cl-pushnew req (oref team waiting-requests) :test #'equal)))
-
 (defmethod slack-equalp ((this slack-request-request) other)
   (and (string= "GET" (oref this type))
        (string= "GET" (oref other type))
@@ -88,56 +84,9 @@
        (equalp (oref this params)
                (oref other params))))
 
-;; (defun slack-perform-retry-request (team)
-;;   (cl-labels
-;;       ((execute-at (req) (oref req execute-at))
-;;        (remove-same-request
-;;         (retries)
-;;         (let ((get-requests '())
-;;               (other '())
-;;               (uniq-get-requests '()))
-
-;;           (dolist (req retries)
-;;             (if (string= "GET" (oref req type))
-;;                 (push req get-requests)
-;;               (push req other)))
-
-;;           (dolist (req (cl-sort get-requests #'<
-;;                                 :key #'execute-at))
-;;             (unless (cl-find-if #'(lambda (r) (slack-equalp req r))
-;;                                 uniq-get-requests)
-;;               (push req uniq-get-requests)))
-;;           (cl-sort (append uniq-get-requests other)
-;;                    #'<
-;;                    :key #'execute-at))))
-;;     (let ((do '())
-;;           (skip '())
-;;           (current (time-to-seconds))
-;;           (retries (remove-same-request (oref team retries))))
-;;       (cl-loop for req in retries
-;;                do (if (and (< (execute-at req) current)
-;;                            (< (length do) 10))
-;;                       (push req do)
-;;                     (push req skip)))
-;;       (when (< 0 (length retries))
-;;         (slack-log (format "Retry Worker TEAM: %s, ALL: %s, DO: %s, SKIP: %s"
-;;                            (oref team name)
-;;                            (length retries)
-;;                            (length do)
-;;                            (length skip))
-;;                    team))
-;;       (oset team retries skip)
-;;       (cl-loop for req in do
-;;                do (slack-request req)))))
-
 (defmethod slack-request-retry-request ((req slack-request-request) retry-after team)
-  ;; (unless (timerp (oref team retry-worker))
-  ;;   (oset team retry-worker
-  ;;         (run-with-idle-timer 1 t #'(lambda () (slack-perform-retry-request team)))))
   (oset req execute-at (+ retry-after (time-to-seconds)))
-  (slack-request-worker-push req)
-  ;; (push req (oref team retries))
-  )
+  (slack-request-worker-push req))
 
 (cl-defmethod slack-request ((req slack-request-request)
                              &key (on-success nil) (on-error nil))

--- a/slack-request.el
+++ b/slack-request.el
@@ -153,6 +153,10 @@
                                               url
                                               params)
                                       team))
+                       (slack-log (format "Request Failed. URL: %s, PARAMS: %s"
+                                          url
+                                          params)
+                                  team)
                        (when (functionp error)
                          (funcall error
                                   :error-thrown error-thrown

--- a/slack-request.el
+++ b/slack-request.el
@@ -102,7 +102,7 @@
                         (format "Request Finished. URL: %s, PARAMS: %s"
                                 url
                                 params)
-                        team)
+                        team :level 'trace)
                        (when (functionp on-success)
                          (funcall on-success)))
            (on-error (&key error-thrown symbol-status response data)
@@ -115,10 +115,14 @@
                                               url
                                               params)
                                       team))
-                       (slack-log (format "Request Failed. URL: %s, PARAMS: %s"
+                       (slack-log (format "Request Failed. URL: %s, PARAMS: %s, ERROR-THROWN: %s, SYMBOL-STATUS: %s, DATA: %s"
                                           url
-                                          params)
-                                  team)
+                                          params
+                                          error-thrown
+                                          symbol-status
+                                          data)
+                                  team
+                                  :level 'error)
                        (when (functionp error)
                          (funcall error
                                   :error-thrown error-thrown

--- a/slack-request.el
+++ b/slack-request.el
@@ -77,7 +77,9 @@
     (apply #'make-instance 'slack-request-request ret)))
 
 (defmethod slack-equalp ((this slack-request-request) other)
-  (and (string= "GET" (oref this type))
+  (and (string= (oref (oref this team) id)
+                (oref (oref other team) id))
+       (string= "GET" (oref this type))
        (string= "GET" (oref other type))
        (string= (oref this url)
                 (oref other url))

--- a/slack-request.el
+++ b/slack-request.el
@@ -58,7 +58,7 @@
    (files :initarg :files :initform nil)
    (headers :initarg :headers :initform nil)
    (timeout :initarg :timeout :initform `,slack-request-timeout)
-   (next-retry-at :initform 0.0 :type float)))
+   (execute-at :initform 0.0 :type float)))
 
 (cl-defun slack-request-create
     (url team &key type success error params data parser sync files headers timeout)

--- a/slack-request.el
+++ b/slack-request.el
@@ -97,7 +97,6 @@
       (cl-labels
           ((on-success (&key data &allow-other-keys)
                        (funcall success :data data)
-                       (oset team retry-after-timer nil)
                        (slack-log
                         (format "Request Finished. URL: %s, PARAMS: %s"
                                 url

--- a/slack-room.el
+++ b/slack-room.el
@@ -367,7 +367,7 @@
 (defmethod slack-room-info-request-params ((room slack-room))
   (list (cons "channel" (oref room id))))
 
-(defmethod slack-room-info-request ((room slack-room) team)
+(defmethod slack-room-create-info-request ((room slack-room) team)
   (cl-labels
       ((on-success
         (&key data &allow-other-keys)
@@ -377,12 +377,15 @@
                    (if (not (string= e "user_disabled"))
                        (message "Failed to request slack-room-info-request: %s" e))))
          (slack-room-update-info room data team))))
-    (slack-request
-     (slack-request-create
-      (slack-room-get-info-url room)
-      team
-      :params (slack-room-info-request-params room)
-      :success #'on-success))))
+    (slack-request-create
+     (slack-room-get-info-url room)
+     team
+     :params (slack-room-info-request-params room)
+     :success #'on-success)))
+
+(defmethod slack-room-info-request ((room slack-room) team)
+  (slack-request
+   (slack-room-create-info-request room team)))
 
 (defmethod slack-room-get-members ((room slack-room))
   (oref room members))

--- a/slack-team.el
+++ b/slack-team.el
@@ -109,6 +109,8 @@ use `slack-change-current-team' to change `slack-current-team'"
    (slack-file-comment-compose-buffer :initform nil :type (or null list))
    (reconnect-url :initform "" :type string)
    (full-and-display-names :initarg :full-and-display-names :initform nil)
+   (websocket-connect-timeout-timer :initform nil)
+   (websocket-connect-timeout-sec :type number :initform 20) ;; websocket url is valid for 30 seconds.
    ))
 
 (cl-defmethod slack-team-kill-buffers ((this slack-team) &key (except nil))

--- a/slack-team.el
+++ b/slack-team.el
@@ -110,6 +110,8 @@ use `slack-change-current-team' to change `slack-current-team'"
    (slack-file-comment-compose-buffer :initform nil :type (or null list))
    (reconnect-url :initform "" :type string)
    (full-and-display-names :initarg :full-and-display-names :initform nil)
+   (retries :initform nil :type (or null list))
+   (retry-worker :initform nil)
    ))
 
 (cl-defmethod slack-team-kill-buffers ((this slack-team) &key (except nil))

--- a/slack-team.el
+++ b/slack-team.el
@@ -88,7 +88,6 @@ use `slack-change-current-team' to change `slack-current-team'"
    (display-profile-image :initarg :display-profile-image :initform nil)
    (display-attachment-image-inline :initarg :display-attachment-image-inline :initform nil)
    (display-file-image-inline :initarg :display-file-image-inline :initform nil)
-   (retry-after-timer :initform nil)
    (waiting-requests :initform nil)
    (authorize-request :initform nil)
    (emoji-download-watch-timer :initform nil)
@@ -297,9 +296,6 @@ you can change current-team with `slack-change-current-team'"
 
 (defmethod slack-team-display-file-image-inlinep ((team slack-team))
   (oref team display-file-image-inline))
-
-(defmethod slack-team-request-suspended-p ((team slack-team))
-  (oref team retry-after-timer))
 
 (provide 'slack-team)
 ;;; slack-team.el ends here

--- a/slack-team.el
+++ b/slack-team.el
@@ -110,8 +110,6 @@ use `slack-change-current-team' to change `slack-current-team'"
    (slack-file-comment-compose-buffer :initform nil :type (or null list))
    (reconnect-url :initform "" :type string)
    (full-and-display-names :initarg :full-and-display-names :initform nil)
-   ;; (retries :initform nil :type (or null list))
-   ;; (retry-worker :initform nil)
    ))
 
 (cl-defmethod slack-team-kill-buffers ((this slack-team) &key (except nil))
@@ -302,14 +300,6 @@ you can change current-team with `slack-change-current-team'"
 
 (defmethod slack-team-request-suspended-p ((team slack-team))
   (oref team retry-after-timer))
-
-(defmethod slack-team-run-retry-request-timer ((team slack-team) retry-after-sec)
-  (cl-labels ((do-request ()
-                          (with-slots (waiting-requests) team
-                            (mapc #'slack-request waiting-requests)
-                            (setq waiting-requests nil))))
-    (oset team retry-after-timer
-          (run-at-time retry-after-sec nil #'do-request))))
 
 (provide 'slack-team)
 ;;; slack-team.el ends here

--- a/slack-team.el
+++ b/slack-team.el
@@ -110,8 +110,8 @@ use `slack-change-current-team' to change `slack-current-team'"
    (slack-file-comment-compose-buffer :initform nil :type (or null list))
    (reconnect-url :initform "" :type string)
    (full-and-display-names :initarg :full-and-display-names :initform nil)
-   (retries :initform nil :type (or null list))
-   (retry-worker :initform nil)
+   ;; (retries :initform nil :type (or null list))
+   ;; (retry-worker :initform nil)
    ))
 
 (cl-defmethod slack-team-kill-buffers ((this slack-team) &key (except nil))

--- a/slack-util.el
+++ b/slack-util.el
@@ -215,6 +215,17 @@ One of 'info, 'debug"
                           payload)))
         (setq buffer-read-only t)))))
 
+(defun slack-log-open-websocket-buffer ()
+  (interactive)
+  (if websocket-debug
+      (progn
+        (let* ((team (slack-team-select))
+               (websocket (oref team ws-conn))
+               (buf (websocket-get-debug-buffer-create websocket)))
+          (funcall slack-buffer-function buf)))
+
+    (error "`websocket-debug` is not t")))
+
 (defun slack-log-open-event-buffer ()
   (interactive)
   (let* ((team (slack-team-select))

--- a/slack-util.el
+++ b/slack-util.el
@@ -220,10 +220,11 @@ One of 'info, 'debug"
   (if websocket-debug
       (progn
         (let* ((team (slack-team-select))
-               (websocket (oref team ws-conn))
-               (buf (websocket-get-debug-buffer-create websocket)))
-          (funcall slack-buffer-function buf)))
-
+               (websocket (oref team ws-conn)))
+          (if websocket
+              (funcall slack-buffer-function
+                       (websocket-get-debug-buffer-create websocket))
+            (error "Websocket is not connected"))))
     (error "`websocket-debug` is not t")))
 
 (defun slack-log-open-event-buffer ()

--- a/slack-util.el
+++ b/slack-util.el
@@ -76,13 +76,14 @@
                                    nil
                                  value)))))))
 
-(cl-defun slack-log (msg team &key (logger #'message))
+(cl-defun slack-log (msg team &key (logger nil))
   (let ((log (format "[%s] %s - %s"
                      (format-time-string "%Y-%m-%d %H:%M:%S")
                      msg
                      (oref team name)))
         (buf (get-buffer-create (slack-log-buffer-name team))))
-    (funcall logger log)
+    (when (functionp logger)
+      (funcall logger log))
     (with-current-buffer buf
       (setq buffer-read-only nil)
       (save-excursion

--- a/slack-util.el
+++ b/slack-util.el
@@ -40,6 +40,25 @@
   "Max Height of image.  nil is unlimited.  integer."
   :group 'slack)
 
+(defconst slack-log-levels
+  '(;; debugging
+    (trace . 40) (debug . 30)
+    ;; information
+    (info . 20)
+    ;; errors
+    (warn . 10) (error . 0))
+  "Named logging levels.")
+
+(defcustom slack-log-level 'info
+  "Used in `slack-message-logger'.
+One of 'info, 'debug"
+  :group 'slack)
+
+(defcustom slack-log-time-format
+  "[%Y-%m-%d %H:%M:%S]"
+  "Time format for log."
+  :group 'slack)
+
 (defalias 'slack-if-let*
   (if (fboundp 'if-let*)
       'if-let*
@@ -75,15 +94,34 @@
                                (if (eq :json-false value)
                                    nil
                                  value)))))))
+(defun slack-log-level-to-int (level)
+  (slack-if-let* ((cell (cl-assoc level slack-log-levels)))
+      (cdr cell)
+    20))
 
-(cl-defun slack-log (msg team &key (logger nil))
-  (let ((log (format "[%s] %s - %s"
-                     (format-time-string "%Y-%m-%d %H:%M:%S")
+
+(defun slack-message-logger (message level team)
+  "Display message using `message'."
+  (let ((user-level (slack-log-level-to-int slack-log-level))
+        (current-level (slack-log-level-to-int level)))
+    (when (<= current-level user-level)
+      (message (format "%s [%s] [%s] %s"
+                       (format-time-string slack-log-time-format)
+                       level
+                       (oref team name)
+                       message)))))
+
+(cl-defun slack-log (msg team &key
+                         (logger #'slack-message-logger)
+                         (level 'debug))
+  (let ((log (format "%s [%s] %s - %s"
+                     (format-time-string slack-log-time-format)
+                     level
                      msg
                      (oref team name)))
         (buf (get-buffer-create (slack-log-buffer-name team))))
     (when (functionp logger)
-      (funcall logger log))
+      (funcall logger msg level team))
     (with-current-buffer buf
       (setq buffer-read-only nil)
       (save-excursion

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -739,7 +739,8 @@
       ((on-error (&key error-thrown &allow-other-keys)
                  (slack-log (format "Slack Reconnect Failed: %s"
                                     (cdr error-thrown))
-                            team))
+                            team)
+                 (slack-ws-set-reconnect-timer team))
        (on-success (data)
                    (slack-on-authorize-for-reconnect data team)))
     (slack-authorize team #'on-error #'on-success)))
@@ -778,8 +779,7 @@ TEAM is one of `slack-teams'"
   (slack-ws-cancel-reconnect-timer team)
   (cl-labels
       ((on-timeout ()
-                   (slack-ws-reconnect team)
-                   (slack-ws-set-reconnect-timer team)))
+                   (slack-ws-reconnect team)))
     (oset team reconnect-timer
           (run-at-time (oref team reconnect-after-sec)
                        nil

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -73,11 +73,6 @@
          (on-close (websocket)
                    (oset team ws-conn nil)
                    (oset team connected nil)
-                   (when (eq 'connecting
-                             (websocket-ready-state websocket))
-                     (slack-ws-close team t)
-                     (slack-ws-set-reconnect-timer team))
-
                    (slack-log (format "Websocket on-close: STATE: %s"
                                       (websocket-ready-state websocket))
                               team :level 'debug))

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -138,8 +138,7 @@
     (push payload waiting-send)
     (cl-labels
         ((reconnect ()
-                    (slack-ws-close team)
-                    (slack-ws-set-reconnect-timer team)))
+                    (slack-ws-close team)))
       (if (websocket-openp ws-conn)
           (condition-case err
               (progn
@@ -667,9 +666,7 @@
 
 (defun slack-ws-ping-timeout (team)
   (slack-log "Slack Websocket PING Timeout." team :level 'warn)
-  (slack-ws-close team)
-  (when (oref team reconnect-auto)
-    (slack-ws-set-reconnect-timer team)))
+  (slack-ws-close team))
 
 (defun slack-ws-cancel-ping-check-timers (team)
   (maphash #'(lambda (key value)

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -51,10 +51,14 @@
                   (oset team connected t)
                   (slack-log "WebSocket on-open"
                              team :level 'debug))
-         (on-close (_websocket)
+         (on-close (websocket)
                    (oset team ws-conn nil)
                    (oset team connected nil)
-                   (slack-ws-close team)
+                   (when (eq 'connecting
+                             (websocket-ready-state websocket))
+                     (slack-ws-close team t)
+                     (slack-ws-set-reconnect-timer team))
+
                    (slack-log "Websocket on-close"
                               team :level 'debug))
          (on-error (_websocket type err)

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -632,8 +632,7 @@
 (defun slack-ws-set-ping-timer (team)
   (slack-ws-cancel-ping-timer team)
   (cl-labels ((ping ()
-                    (slack-ws-ping team)
-                    (slack-ws-set-ping-timer team)))
+                    (slack-ws-ping team)))
     (oset team ping-timer (run-at-time 10 nil #'ping))))
 
 (defun slack-ws-current-time-str ()
@@ -796,6 +795,7 @@ TEAM is one of `slack-teams'"
          (timer (gethash key (oref team ping-check-timers))))
     (slack-log (format "Receive PONG: %s" key)
                team :level 'trace)
+    (slack-ws-set-ping-timer team)
     (when timer
       (cancel-timer timer)
       (remhash key (oref team ping-check-timers))

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -89,9 +89,12 @@
                   (slack-log "Slack Websocket Closed" team)))))
     (if (listp team)
         (progn
-          (mapc #'close team))
-      (close team))
-    (slack-request-worker-quit)))
+          (mapc #'close team)
+          (slack-request-worker-quit))
+      (close team)
+      (slack-request-worker-remove-request team)
+      )
+    ))
 
 
 (defun slack-ws-send (payload team)

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -740,9 +740,10 @@
 
 (defun slack-authorize-for-reconnect (team)
   (cl-labels
-      ((on-error (&key error-thrown &allow-other-keys)
-                 (slack-log (format "Slack Reconnect Failed: %s"
-                                    (cdr error-thrown))
+      ((on-error (&key error-thrown symbol-status &allow-other-keys)
+                 (slack-log (format "Slack Reconnect Failed: %s, %s"
+                                    error-thrown
+                                    symbol-status)
                             team)
                  (slack-ws-set-reconnect-timer team))
        (on-success (data)

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -253,7 +253,8 @@
                          (mapconcat #'(lambda (u) (oref u user-name))
                                     visible-users
                                     ", "))
-                 team))))))))
+                 team
+                 :level 'info))))))))
 
 (defun slack-ws-handle-user-typing (payload team)
   (let* ((user (slack-user-name (plist-get payload :user) team))
@@ -295,7 +296,8 @@
                                                                         team)
                                                       :name)
                                            (slack-team-name team))
-                                   team)))))
+                                   team
+                                   :level 'info)))))
 
 (defun slack-ws-handle-im-open (payload team)
   (cl-labels
@@ -305,7 +307,7 @@
          im team
          :after-success #'(lambda (&rest _ignore)
                             (slack-log (format "Direct Message Channel with %s is Open"
-                                               (slack-user-name (oref im user) team))
+                                               (slack-user-name (oref im user) team :level 'info))
                                        team))
          :async t)))
     (let ((exist (slack-room-find (plist-get payload :channel) team)))
@@ -327,7 +329,7 @@
       (oset im is-open nil)
       (slack-log (format "Direct Message Channel with %s is Closed"
                          (slack-user-name (oref im user) team))
-                 team))))
+                 team :level 'info))))
 
 (defun slack-ws-handle-message (payload team)
   (let ((subtype (plist-get payload :subtype)))
@@ -508,7 +510,7 @@
     (slack-room-info-request channel team)
     (slack-log (format "Created channel %s"
                        (slack-room-display-name channel))
-               team)))
+               team :level 'info)))
 
 (defun slack-ws-handle-room-archive (payload team)
   (let* ((id (plist-get payload :channel))
@@ -516,7 +518,7 @@
     (oset room is-archived t)
     (slack-log (format "Channel: %s is archived"
                        (slack-room-display-name room))
-               team)))
+               team :level 'info)))
 
 (defun slack-ws-handle-room-unarchive (payload team)
   (let* ((id (plist-get payload :channel))
@@ -524,7 +526,7 @@
     (oset room is-archived nil)
     (slack-log (format "Channel: %s is unarchived"
                        (slack-room-display-name room))
-               team)))
+               team :level 'info)))
 
 (defun slack-ws-handle-channel-deleted (payload team)
   (let ((id (plist-get payload :channel)))
@@ -539,21 +541,21 @@
     (slack-log (format "Renamed channel from %s to %s"
                        old-name
                        new-name)
-               team)))
+               team :level 'info)))
 (defun slack-ws-handle-group-joined (payload team)
   (let ((group (slack-room-create (plist-get payload :channel) team 'slack-group)))
     (push group (oref team groups))
     (slack-room-info-request group team)
     (slack-log (format "Joined group %s"
                        (slack-room-display-name group))
-               team)))
+               team :level 'info)))
 
 (defun slack-ws-handle-channel-joined (payload team)
   (let ((channel (slack-room-find (plist-get (plist-get payload :channel) :id) team)))
     (slack-room-info-request channel team)
     (slack-log (format "Joined channel %s"
                        (slack-room-display-name channel))
-               team)))
+               team :level 'info)))
 
 (defun slack-ws-handle-presence-change (payload team)
   (let* ((id (plist-get payload :user))

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -86,8 +86,10 @@
                   (websocket-close ws-conn)
                   (slack-log "Slack Websocket Closed" team)))))
     (if (listp team)
-        (mapc #'close team)
-      (close team))))
+        (progn
+          (mapc #'close team))
+      (close team))
+    (slack-request-worker-quit)))
 
 
 (defun slack-ws-send (payload team)

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -48,10 +48,14 @@
                      (slack-ws-on-message websocket frame team))
          (on-open (_websocket)
                   (oset team reconnect-count 0)
-                  (oset team connected t))
+                  (oset team connected t)
+                  (slack-log "WebSocket on-open"
+                             team :level 'debug))
          (on-close (_websocket)
                    (oset team ws-conn nil)
-                   (oset team connected nil))
+                   (oset team connected nil)
+                   (slack-log "Websocket on-close"
+                              team :level 'debug))
          (on-error (_websocket type err)
                    (slack-log (format "Error on `websocket-open'. TYPE: %s, ERR: %s"
                                       type err)

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -59,7 +59,8 @@
                      (slack-ws-close team t)
                      (slack-ws-set-reconnect-timer team))
 
-                   (slack-log "Websocket on-close"
+                   (slack-log (format "Websocket on-close: STATE: %s"
+                                      (websocket-ready-state websocket))
                               team :level 'debug))
          (on-error (_websocket type err)
                    (slack-log (format "Error on `websocket-open'. TYPE: %s, ERR: %s"

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -154,7 +154,7 @@
           (slack-cancel-notify-adandon-reconnect)
           (slack-ws-set-ping-timer team)
           (slack-ws-resend team)
-          (slack-log "Slack Websocket Is Ready!" team))
+          (slack-log "Slack Websocket Is Ready!" team :level 'info))
          ((plist-get decoded-payload :reply_to)
           (slack-ws-handle-reply decoded-payload team))
          ((string= type "message")

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -54,6 +54,7 @@
          (on-close (_websocket)
                    (oset team ws-conn nil)
                    (oset team connected nil)
+                   (slack-ws-close team)
                    (slack-log "Websocket on-close"
                               team :level 'debug))
          (on-error (_websocket type err)

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -58,7 +58,7 @@
     (cancel-timer (oref team websocket-connect-timeout-timer))
     (oset team websocket-connect-timeout-timer nil)))
 
-(cl-defun slack-ws-open (team &optional ws-url &key (on-open nil))
+(cl-defun slack-ws-open (team &key (on-open nil) (ws-url nil))
   (if (and (oref team ws-conn) (websocket-openp (oref team ws-conn)))
       (slack-log "Websocket is Already Open" team)
     (slack-ws-set-connect-timeout-timer team)
@@ -732,7 +732,7 @@
                                   slack-message-edit-buffer
                                   slack-message-share-buffer
                                   slack-room-message-compose-buffer))))
-      (slack-ws-open team nil :on-open #'on-open))))
+      (slack-ws-open team :on-open #'on-open))))
 
 (defun slack-authorize-for-reconnect (team)
   (cl-labels
@@ -754,7 +754,7 @@ TEAM is one of `slack-teams'"
               (use-reconnect-url ()
                                  (slack-log "Reconnect with reconnect-url" team)
                                  (slack-ws-open team
-                                                (oref team reconnect-url)))
+                                                :ws-url (oref team reconnect-url)))
               (do-reconnect (team)
                             (cl-incf (oref team reconnect-count))
                             (slack-ws-close team nil)

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -55,7 +55,8 @@
          (on-error (_websocket type err)
                    (slack-log (format "Error on `websocket-open'. TYPE: %s, ERR: %s"
                                       type err)
-                              team)))
+                              team
+                              :level 'error)))
       (oset team ws-conn
             (condition-case error-var
                 (websocket-open (or ws-url (oref team ws-url))
@@ -67,7 +68,8 @@
               (error
                (slack-log (format "An Error occured while opening websocket connection: %s"
                                   error-var)
-                          team)
+                          team
+                          :level 'error)
                (slack-ws-close team)
                nil))))))
 
@@ -102,7 +104,8 @@
                 (cl-remove-if #'(lambda (p) (string= payload p))
                               waiting-send)))
       (websocket-closed (slack-ws-reconnect team))
-      (websocket-illegal-frame (slack-log "Sent illegal frame." team)
+      (websocket-illegal-frame (slack-log "Sent illegal frame." team
+                                          :level 'error)
                                (slack-ws-close team))
       (error (slack-ws-reconnect team)))))
 
@@ -636,7 +639,7 @@
                                #'(lambda ()
                                    (slack-log
                                     "Reconnect Count Exceeded. Manually invoke `slack-start'."
-                                    team))))))
+                                    team :level 'error))))))
 
 (defun slack-cancel-notify-adandon-reconnect ()
   (if (and slack-disconnected-timer

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -609,7 +609,7 @@
 
 
 (defun slack-ws-ping-timeout (team)
-  (slack-log "Slack Websocket PING Timeout." team)
+  (slack-log "Slack Websocket PING Timeout." team :level 'warn)
   (slack-ws-close team)
   (when (oref team reconnect-auto)
     (if (timerp (oref team reconnect-timer))
@@ -728,7 +728,9 @@ TEAM is one of `slack-teams'"
         (slack-log (format "Slack Websocket Try To Reconnect %s/%s"
                            reconnect-count
                            reconnect-max)
-                   team)))))
+                   team
+                   :level 'warn
+                   )))))
 
 (defun slack-ws-cancel-reconnect-timer (team)
   (with-slots (reconnect-timer) team

--- a/slack.el
+++ b/slack.el
@@ -207,6 +207,10 @@ never means never show typing indicator."
                (team)
                (slack-team-kill-buffers team)
                (slack-ws-close team)
+               (when (timerp (oref team retry-worker))
+                 (cancel-timer (oref team retry-worker))
+                 (oset team retry-worker nil))
+
                (when (slack-team-need-token-p team)
                  (slack-request-token team)
                  (kill-new (oref team token))

--- a/slack.el
+++ b/slack.el
@@ -67,6 +67,7 @@
 
 (require 'slack-websocket)
 (require 'slack-request)
+(require 'slack-request-worker)
 
 (defgroup slack nil
   "Emacs Slack Client"
@@ -207,9 +208,9 @@ never means never show typing indicator."
                (team)
                (slack-team-kill-buffers team)
                (slack-ws-close team)
-               (when (timerp (oref team retry-worker))
-                 (cancel-timer (oref team retry-worker))
-                 (oset team retry-worker nil))
+               ;; (when (timerp (oref team retry-worker))
+               ;;   (cancel-timer (oref team retry-worker))
+               ;;   (oset team retry-worker nil))
 
                (when (slack-team-need-token-p team)
                  (slack-request-token team)

--- a/slack.el
+++ b/slack.el
@@ -208,10 +208,6 @@ never means never show typing indicator."
                (team)
                (slack-team-kill-buffers team)
                (slack-ws-close team)
-               ;; (when (timerp (oref team retry-worker))
-               ;;   (cancel-timer (oref team retry-worker))
-               ;;   (oset team retry-worker nil))
-
                (when (slack-team-need-token-p team)
                  (slack-request-token team)
                  (kill-new (oref team token))

--- a/slack.el
+++ b/slack.el
@@ -172,13 +172,15 @@ never means never show typing indicator."
    (data "slack-authorize")
    (slack-log (format "Slack Authorization Finished" (oref team name)) team)
    (let ((team (slack-update-team data team)))
-     (slack-channel-list-update team)
-     (slack-group-list-update team)
-     (slack-im-list-update team)
-     (slack-bot-list-update team)
-     (slack-request-emoji team)
-     (slack-update-modeline)
-     (slack-ws-open team))))
+     (cl-labels
+         ((on-open ()
+                   (slack-channel-list-update team)
+                   (slack-group-list-update team)
+                   (slack-im-list-update team)
+                   (slack-bot-list-update team)
+                   (slack-request-emoji team)
+                   (slack-update-modeline)))
+       (slack-ws-open team nil :on-open #'on-open)))))
 
 (defun slack-on-authorize-e
     (&key error-thrown &allow-other-keys &rest_)

--- a/slack.el
+++ b/slack.el
@@ -180,7 +180,7 @@ never means never show typing indicator."
                    (slack-bot-list-update team)
                    (slack-request-emoji team)
                    (slack-update-modeline)))
-       (slack-ws-open team nil :on-open #'on-open)))))
+       (slack-ws-open team :on-open #'on-open)))))
 
 (defun slack-on-authorize-e
     (&key error-thrown &allow-other-keys &rest_)


### PR DESCRIPTION
inhibit making a lot of connection when booting.

```
(defcustom slack-request-worker-max-request-limit 30
  "Max request count perform simultaneously."
  :group 'slack)
```

this variable limiting number of connection when using `slack-request-worker`.
currently this worker is used to fetch channel(group, im) list and information of each channels when booting.