### PR TITLE
Add another "Easy Way" of token generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,14 @@ Emacs client for [Slack](https://slack.com/)
 ```
 
 ## How to get token (the easy way)
+### 1. From a query param
 
+ 1. Log into the Slack team you're interested in with a web browser
+ 2. Open DevTools
+ 3. Open Network tab
+ 4. Search for (Ctrl-F) "xoxs-" and copy token from Query String Parameters
+
+### 2. With a legacy token
 1. Go to "https://api.slack.com/custom-integrations/legacy-tokens".
 2. Create token for the teams you want to have integrate with.
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,8 @@ Emacs client for [Slack](https://slack.com/)
 
 ## How to get token (the easy way)
 
-1. Log into the Slack team you're interested in with a web browser
-2. Open DevTools
-3. Open Network tab
-4. Search for (Ctrl-F) "xoxs-" and copy `token` from Query String Parameters
+1. Go to "https://api.slack.com/custom-integrations/legacy-tokens".
+2. Create token for the teams you want to have integrate with.
 
 ## How to get token (the harder yet officially sanctioned way)
 


### PR DESCRIPTION
A small update to the README that points out that users can generate legacy API tokens.