### PR TITLE
Depend on Emacs 25

### DIFF
--- a/slack-pkg.el
+++ b/slack-pkg.el
@@ -5,5 +5,6 @@
     (oauth2 "0.10")
     (circe "2.2")
     (alert "1.2")
-    (emojify "0.2"))
+    (emojify "0.2")
+    (emacs "25"))
   :url "https://github.com/yuya373/emacs-slack")


### PR DESCRIPTION
Installing on Emacs 24 does not work because the package is using
new constructs from emacs 25.
I got errors from `cl-` related structures among others. The `cl-generic` package helps a bit here but still some missing symbols after installing that.