### PR TITLE
escape <!data...> format

### DIFF
--- a/slack-message-formatter.el
+++ b/slack-message-formatter.el
@@ -86,7 +86,9 @@
     (date_long_pretty . "%A %B %d,%Y")
     (time . "%H:%M")
     (time_secs . "%H:%M:%S"))
-  "Date formats for Slack's date formatting.\n see https://api.slack.com/docs/message-formatting"
+  "Date formats for Slack's date token.
+this format string passed to `format-time-string' function.
+see \"Formatting dates\" section in https://api.slack.com/docs/message-formatting"
   :group 'slack)
 
 (defun slack-message-put-header-property (header)

--- a/slack-util.el
+++ b/slack-util.el
@@ -184,7 +184,9 @@ One of 'info, 'debug"
   (get-text-property 0 'ts (thing-at-point 'line)))
 
 (defun slack-linkfy (text link)
-  (format "<%s|%s>" link text))
+  (if (not (slack-string-blankp link))
+      (format "<%s|%s>" link text)
+    text))
 
 (defun slack-string-blankp (str)
   (if str


### PR DESCRIPTION
- parse `<!date...> ` and display time string.
- add custom variable `slack-date-formats`

token(date_short_pretty) in `slack-date-formats` is written "Formatting dates" section in https://api.slack.com/docs/message-formatting