### PR TITLE
Fix ws close

### DIFF
--- a/slack-team.el
+++ b/slack-team.el
@@ -112,6 +112,7 @@ use `slack-change-current-team' to change `slack-current-team'"
    (websocket-connect-timeout-timer :initform nil)
    (websocket-connect-timeout-sec :type number :initform 20) ;; websocket url is valid for 30 seconds.
    (mark-as-read-immediately :initarg :mark-as-read-immediately :initform t)
+   (inhibit-reconnection :initform nil)
    ))
 
 (cl-defmethod slack-team-kill-buffers ((this slack-team) &key (except nil))

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -47,7 +47,7 @@
       ((on-timeout ()
                    (slack-log (format "websocket open timeout")
                               team)
-                   (slack-ws-close team t)
+                   (slack-ws-close team)
                    (slack-ws-set-reconnect-timer team)))
     (oset team websocket-connect-timeout-timer
           (run-at-time (oref team websocket-connect-timeout-sec)
@@ -145,7 +145,8 @@
     (push payload waiting-send)
     (cl-labels
         ((reconnect ()
-                    (slack-ws-close team)))
+                    (slack-ws-close team)
+                    (slack-ws-set-reconnect-timer team)))
       (if (websocket-openp ws-conn)
           (condition-case err
               (progn
@@ -172,8 +173,8 @@
          (code (plist-get err :code)))
     (cond
      ((eq 1 code)
-      (slack-authorize-for-reconnect team))
       (slack-ws-close team)
+      (slack-ws-set-reconnect-timer team))
      (t (slack-log (format "Unknown Error: %s, MSG: %s"
                            code (plist-get err :msg))
                    team)))))
@@ -673,7 +674,8 @@
 
 (defun slack-ws-ping-timeout (team)
   (slack-log "Slack Websocket PING Timeout." team :level 'warn)
-  (slack-ws-close team))
+  (slack-ws-close team)
+  (slack-ws-set-reconnect-timer team))
 
 (defun slack-ws-cancel-ping-check-timers (team)
   (maphash #'(lambda (key value)


### PR DESCRIPTION
stop reconnect when call `slack-ws-close` interactively