### PR TITLE
Check for graphic display before rendering image

### DIFF
--- a/slack-util.el
+++ b/slack-util.el
@@ -254,7 +254,7 @@ One of 'info, 'debug"
                                                   (list :max-height max-height))
                                               (if max-width
                                                   (list :max-width max-width))))))
-    (if imagemagick-available-p
+    (if (and (display-graphic-p) imagemagick-available-p)
         (slack-image-shrink image max-height)
       image)))
 


### PR DESCRIPTION
Resolves problems observed in #285 when emacs is being used without a graphical system (terminal).