### PR TITLE
check message exists or not

### DIFF
--- a/slack-message.el
+++ b/slack-message.el
@@ -338,7 +338,11 @@
                   (slack-buffer-update buf message :replace replace)))))))
 
 (defmethod slack-message-update ((message slack-message) team &optional replace no-notify)
-  (slack-if-let* ((room (slack-room-find (oref message channel) team)))
+  (slack-if-let*
+      ((room (slack-room-find (oref message channel) team))
+       (ts (slack-ts message))
+       (no-same-message (not (slack-room-find-message room ts))))
+
       (progn
         (slack-room-push-message room message)
         (slack-room-update-latest room message)


### PR DESCRIPTION
close #334 

Slack's server send me `type: message` json in addition to `reply_to` json.
This will cause the message to be drawn twice in the buffer.

```
[2018-08-17 18:25:20] (:type message :user U838383 :text fuga :team T83838383 :channel D838383 :event_ts 1534497919.000100 :ts 1534497919.000100)
[2018-08-17 18:25:20] (:ok t :reply_to 16847 :ts 1534497919.000100 :text fuga)
```