### PR TITLE
Ondemand user info

### DIFF
--- a/slack-authorize.el
+++ b/slack-authorize.el
@@ -69,7 +69,7 @@
                                                                              team paths)))
                                (on-open ()
                                         (slack-conversations-list-update team)
-                                        (slack-user-list-update team)
+                                        ;; (slack-user-list-update team)
                                         (slack-download-emoji team #'on-emoji-download)
                                         (slack-command-list-update team)
                                         (slack-usergroup-list-update team)

--- a/slack-conversations.el
+++ b/slack-conversations.el
@@ -341,6 +341,10 @@
                                (slack-conversations-info-request
                                 room team)))
                   (slack-users-counts team)
+                  (slack-user-info-request
+                   (mapcar #'(lambda (im) (oref im user))
+                           (oref team ims))
+                   team)
                   (when (functionp after-success)
                     (funcall after-success team))
                   (slack-log "Slack Channel List Updated"

--- a/slack-conversations.el
+++ b/slack-conversations.el
@@ -454,19 +454,9 @@
                          (next-cursor (or (plist-get meta :next_cursor) ""))
                          (messages (cl-loop for e in (plist-get data :messages)
                                             collect (slack-message-create e team room)))
-                         (exists-user-ids (mapcar #'(lambda (e) (plist-get e :id))
-                                                  (oref team users)))
-                         (user-ids (cl-remove-if #'(lambda (e) (cl-find e exists-user-ids :test #'string=))
-                                                 (cl-remove-duplicates
-                                                  (let ((result))
-                                                    (cl-loop for m in messages
-                                                             do (progn
-                                                                  (cl-loop for reaction in (slack-message-reactions m)
-                                                                           do (cl-loop for user in (oref reaction users)
-                                                                                       do (push user result)))
-                                                                  (push (slack-message-sender-id m) result)))
-                                                    result)
-                                                  :test #'string=))))
+                         (user-ids (slack-team-missing-user-ids
+                                    team (cl-loop for m in messages
+                                                  nconc (slack-message-user-ids m)))))
                     (if (< 0 (length user-ids))
                         (slack-user-info-request
                          user-ids team
@@ -502,11 +492,7 @@
                   (let* ((meta (plist-get data :response_metadata))
                          (next-cursor (and meta (plist-get meta :next_cursor)))
                          (members (plist-get data :members))
-                         (user-ids (mapcar #'(lambda (e) (plist-get e :id))
-                                           (oref team users)))
-                         (missing-user-ids (cl-remove-if #'(lambda (e)
-                                                             (cl-find e user-ids :test #'string=))
-                                                         members)))
+                         (missing-user-ids (slack-team-missing-user-ids team members)))
                     (oset room members
                           (cl-remove-duplicates (append (oref room members)
                                                         members)

--- a/slack-conversations.el
+++ b/slack-conversations.el
@@ -115,65 +115,61 @@
       :success (slack-conversations-success-handler team)))))
 
 (defun slack-conversations-invite (room team)
-  (slack-conversations-members
-   room team
-   #'(lambda ()
-       (let* ((channel (oref room id))
-              (user-names (slack-user-names
-                           team #'(lambda (users)
-                                    (cl-remove-if #'(lambda (e)
-                                                      (or (string= (oref team self-id)
-                                                                   (plist-get e :id))
-                                                          (string= (plist-get e :id)
-                                                                   "USLACKBOT")
-                                                          (cl-find (plist-get e :id)
-                                                                   (oref room members)
-                                                                   :test #'string=)))
-                                                  users))))
-              (users nil))
-         (cl-labels
-             ((already-selected-p
-               (user-name)
-               (cl-find-if #'(lambda (e)
-                               (string= e
-                                        (plist-get (cdr user-name)
-                                                   :id)))
-                           users))
-              (filter-selected (user-names)
-                               (cl-remove-if #'already-selected-p
-                                             user-names)))
-           (cl-loop for i from 1 upto 30
-                    as candidates = (filter-selected user-names)
-                    as selected = (slack-select-from-list
-                                      (candidates "Select User: "))
-                    while selected
-                    do (push (plist-get selected :id) users)))
-         (setq users (mapconcat #'identity users ","))
-
-         (cl-labels
-             ((errors-handler
-               (errors)
-               (let ((message
-                      (mapconcat #'(lambda (err)
-                                     (let ((msg (plist-get err :error))
-                                           (user (plist-get err :user)))
-                                       (format "%s%s"
-                                               (replace-regexp-in-string "_" " " msg)
-                                               (or (and user (format ": %s" user))
-                                                   ""))))
-                                 errors
-                                 ", ")))
-                 (slack-log message team :level 'error))))
-           (slack-request
-            (slack-request-create
-             slack-conversations-invite-url
-             team
-             :type "POST"
-             :params (list (cons "channel" channel)
-                           (cons "users" users))
-             :success (slack-conversations-success-handler team
-                                                           :on-errors
-                                                           #'errors-handler))))))))
+  (let* ((channel (oref room id))
+         (user-names (slack-user-names
+                      team #'(lambda (users)
+                               (cl-remove-if #'(lambda (e)
+                                                 (or (string= (oref team self-id)
+                                                              (plist-get e :id))
+                                                     (string= (plist-get e :id)
+                                                              "USLACKBOT")
+                                                     (cl-find (plist-get e :id)
+                                                              (oref room members)
+                                                              :test #'string=)))
+                                             users))))
+         (users nil))
+    (cl-labels
+        ((already-selected-p
+          (user-name)
+          (cl-find-if #'(lambda (e)
+                          (string= e
+                                   (plist-get (cdr user-name)
+                                              :id)))
+                      users))
+         (filter-selected (user-names)
+                          (cl-remove-if #'already-selected-p
+                                        user-names)))
+      (cl-loop for i from 1 upto 30
+               as candidates = (filter-selected user-names)
+               as selected = (slack-select-from-list
+                                 (candidates "Select User: "))
+               while selected
+               do (push (plist-get selected :id) users)))
+    (setq users (mapconcat #'identity users ","))
+    (cl-labels
+        ((errors-handler
+          (errors)
+          (let ((message
+                 (mapconcat #'(lambda (err)
+                                (let ((msg (plist-get err :error))
+                                      (user (plist-get err :user)))
+                                  (format "%s%s"
+                                          (replace-regexp-in-string "_" " " msg)
+                                          (or (and user (format ": %s" user))
+                                              ""))))
+                            errors
+                            ", ")))
+            (slack-log message team :level 'error))))
+      (slack-request
+       (slack-request-create
+        slack-conversations-invite-url
+        team
+        :type "POST"
+        :params (list (cons "channel" channel)
+                      (cons "users" users))
+        :success (slack-conversations-success-handler team
+                                                      :on-errors
+                                                      #'errors-handler))))))
 
 (defun slack-conversations-join (room team &optional on-success)
   (cl-labels
@@ -255,28 +251,25 @@
                                                       #'on-success))))))
 
 (defun slack-conversations-kick (room team)
-  (slack-conversations-members
-   room team
-   #'(lambda ()
-       (let* ((candidates (cl-loop for user in (slack-user-names team)
-                                   if (cl-find (plist-get (cdr user) :id)
-                                               (oref room members)
-                                               :test #'string=)
-                                   collect user))
-              (selected (funcall slack-completing-read-function
-                                 "Select User: "
-                                 candidates
-                                 nil t))
-              (user (cdr-safe (cl-assoc selected candidates :test #'string=))))
-         (when user
-           (slack-request
-            (slack-request-create
-             slack-conversations-kick-url
-             team
-             :type "POST"
-             :params (list (cons "channel" (oref room id))
-                           (cons "user" (plist-get user :id)))
-             :success (slack-conversations-success-handler team))))))))
+  (let* ((candidates (cl-loop for user in (slack-user-names team)
+                              if (cl-find (plist-get (cdr user) :id)
+                                          (oref room members)
+                                          :test #'string=)
+                              collect user))
+         (selected (funcall slack-completing-read-function
+                            "Select User: "
+                            candidates
+                            nil t))
+         (user (cdr-safe (cl-assoc selected candidates :test #'string=))))
+    (when user
+      (slack-request
+       (slack-request-create
+        slack-conversations-kick-url
+        team
+        :type "POST"
+        :params (list (cons "channel" (oref room id))
+                      (cons "user" (plist-get user :id)))
+        :success (slack-conversations-success-handler team))))))
 
 (defun slack-conversations-list (team success-callback &optional types)
   (let ((cursor nil)
@@ -487,21 +480,19 @@
         :success (slack-conversations-success-handler
                   team :on-success #'success))))))
 
-(defun slack-conversations-members (room team &optional after-success)
+(defun slack-conversations-members (room team &optional cursor after-success)
   (if (oref room members-loaded-p)
       (when (functionp after-success)
-        (funcall after-success))
+        (funcall after-success (oref room members) ""))
     (cl-labels
-        ((callback (next-cursor)
-                   (if (and next-cursor (< 0 (length next-cursor)))
-                       (request next-cursor)
-                     (progn
-                       (oset room members-loaded-p t)
-                       (when (functionp after-success)
-                         (funcall after-success)))))
+        ((callback (members next-cursor)
+                   (when (< (length next-cursor) 1)
+                     (oset room members-loaded-p t))
+                   (when (functionp after-success)
+                     (funcall after-success members next-cursor)))
          (success (data)
                   (let* ((meta (plist-get data :response_metadata))
-                         (next-cursor (and meta (plist-get meta :next_cursor)))
+                         (next-cursor (or (and meta (plist-get meta :next_cursor)) ""))
                          (members (plist-get data :members))
                          (missing-user-ids (slack-team-missing-user-ids team members)))
                     (oset room members
@@ -514,19 +505,17 @@
                          missing-user-ids
                          team
                          :after-success #'(lambda ()
-                                            (callback next-cursor)))
-                      (callback next-cursor))))
-         (request (&optional cursor)
-                  (slack-request
-                   (slack-request-create
-                    slack-conversations-members-url
-                    team
-                    :params (list (cons "channel" (oref room id))
-                                  (and cursor (cons "cursor" cursor))
-                                  (cons "limit" "1000"))
-                    :success (slack-conversations-success-handler
-                              team :on-success #'success)))))
-      (request))))
+                                            (callback members next-cursor)))
+                      (callback members next-cursor)))))
+      (slack-request
+       (slack-request-create
+        slack-conversations-members-url
+        team
+        :params (list (cons "channel" (oref room id))
+                      (cons "limit" "100")
+                      (and cursor (cons "cursor" cursor)))
+        :success (slack-conversations-success-handler
+                  team :on-success #'success))))))
 
 (cl-defun slack-conversations-open (team &key room user-ids)
   (let ((channel (or (and room (oref room id))

--- a/slack-file-list-buffer.el
+++ b/slack-file-list-buffer.el
@@ -124,7 +124,9 @@
         (ts (slack-ts message))
         (team (oref this team)))
     (lui-insert-with-text-properties
-     (slack-message-to-string message ts team)
+     (format "@%s %s"
+             (slack-user-name (oref message user) team)
+             (slack-message-to-string message ts team))
      'not-tracked-p not-tracked-p
      'ts ts
      'slack-last-ts lui-time-stamp-last)

--- a/slack-file.el
+++ b/slack-file.el
@@ -563,20 +563,28 @@
                                         (count "100")
                                         (after-success nil))
   (cl-labels
-      ((success (&key data &allow-other-keys)
-                (let ((files (mapcar #'slack-file-create
-                                     (plist-get data :files)))
-                      (paging (plist-get data :paging)))
+      ((callback (paging)
+                 (when (functionp after-success)
+                   (funcall after-success
+                            (plist-get paging :page)
+                            (plist-get paging :pages))))
+       (success (&key data &allow-other-keys)
+                (let* ((files (mapcar #'slack-file-create
+                                      (plist-get data :files)))
+                       (paging (plist-get data :paging))
+                       (user-ids (slack-team-missing-user-ids
+                                  team (cl-loop for file in files
+                                                collect (oref file user)))))
                   (if (string= page "1")
                       (oset team files files)
                     (oset team files (append (oref team files) files)))
                   (oset team files (cl-sort (oref team files)
                                             #'<
                                             :key #'(lambda (e) (oref e created))))
-                  (when (functionp after-success)
-                    (funcall after-success
-                             (plist-get paging :page)
-                             (plist-get paging :pages))))))
+                  (if (< 0 (length user-ids))
+                      (slack-users-info-request
+                       user-ids team :after-success #'(lambda () (callback paging)))
+                    (callback paging)))))
     (slack-request
      (slack-request-create
       slack-file-list-url

--- a/slack-file.el
+++ b/slack-file.el
@@ -558,6 +558,10 @@
 (cl-defmethod slack-thread-message-p ((_this slack-file))
   nil)
 
+(cl-defmethod slack-message-user-ids ((this slack-file))
+  (with-slots (user) this
+    (list user)))
+
 (cl-defun slack-file-list-request (team &key
                                         (page "1")
                                         (count "100")
@@ -574,7 +578,7 @@
                        (paging (plist-get data :paging))
                        (user-ids (slack-team-missing-user-ids
                                   team (cl-loop for file in files
-                                                collect (oref file user)))))
+                                                nconc (slack-message-user-ids file)))))
                   (if (string= page "1")
                       (oset team files files)
                     (oset team files (append (oref team files) files)))

--- a/slack-message-buffer.el
+++ b/slack-message-buffer.el
@@ -344,19 +344,12 @@
 
 (cl-defmethod slack-buffer-display-pins-list ((this slack-message-buffer))
   (with-slots (room team) this
-    (cl-labels
-        ((on-pins-list (&key data &allow-other-keys)
-                       (slack-request-handle-error
-                        (data "slack-room-pins-list")
-                        (let* ((buf (slack-create-pinned-items-buffer
-                                     room team (plist-get data :items))))
-                          (slack-buffer-display buf)))))
-      (slack-request
-       (slack-request-create
-        slack-room-pins-list-url
-        team
-        :params (list (cons "channel" (oref room id)))
-        :success #'on-pins-list)))))
+    (slack-pins-list
+     room team
+     #'(lambda (items)
+         (let* ((buf (slack-create-pinned-items-buffer
+                      room team items)))
+           (slack-buffer-display buf))))))
 
 (cl-defmethod slack-buffer-display-user-profile ((this slack-message-buffer))
   (with-slots (room team) this

--- a/slack-message-formatter.el
+++ b/slack-message-formatter.el
@@ -351,19 +351,18 @@ see \"Formatting dates\" section in https://api.slack.com/docs/message-formattin
       team))))
 
 (defun slack-unescape-@ (text team)
-  (let ((user-regexp "<@\\(U.*?\\)\\(|.*?\\)?>"))
-    (cl-labels ((replace
-                 (text)
-                 (let ((user-id (match-string 1 text))
-                       (label (match-string 2 text)))
-                   (concat "@" (or (and label (substring label 1))
-                                   (slack-if-let* ((user (slack-user--find user-id team)))
-                                       (plist-get user :name)
-                                     (slack-log (format "User not found. ID: %S" user-id) team)
-                                     "<Unknown USER>"))))))
-      (replace-regexp-in-string user-regexp
-                                #'replace
-                                text t t))))
+  (cl-labels ((replace
+               (text)
+               (let ((user-id (match-string 1 text))
+                     (label (match-string 2 text)))
+                 (concat "@" (or (and label (substring label 1))
+                                 (slack-if-let* ((user (slack-user--find user-id team)))
+                                     (plist-get user :name)
+                                   (slack-log (format "User not found. ID: %S" user-id) team)
+                                   "<Unknown USER>"))))))
+    (replace-regexp-in-string slack-message-user-regexp
+                              #'replace
+                              text t t)))
 
 (defun slack-unescape-channel (text team)
   (let ((channel-regexp "<#\\(C.*?\\)\\(|.*?\\)?>"))

--- a/slack-message.el
+++ b/slack-message.el
@@ -37,6 +37,7 @@
 (declare-function slack-thread-create "slack-thread")
 
 (defvar slack-current-buffer)
+(defvar slack-message-user-regexp "<@\\([WU].*?\\)\\(|.*?\\)?>")
 
 (defcustom slack-message-custom-delete-notifier nil
   "Custom notification function for deleted message.\ntake 3 Arguments.\n(lambda (MESSAGE ROOM TEAM) ...)."
@@ -341,6 +342,17 @@
 (cl-defmethod slack-message-user-ids ((this slack-message))
   (let ((result))
     (push (slack-message-sender-id this) result)
+    (with-slots (text) this
+      (when text
+        (let ((start 0))
+          (while (and (< start (length text))
+                      (string-match slack-message-user-regexp
+                                    text
+                                    start))
+            (let ((user-id (match-string 1 text)))
+              (when user-id
+                (push user-id result)))
+            (setq start (match-end 0))))))
     (cl-loop for r in (slack-message-reactions this)
              do (cl-loop for u in (oref r users)
                          do (push u result)))

--- a/slack-message.el
+++ b/slack-message.el
@@ -338,5 +338,13 @@
            (oref this pinned-to)
            :test #'string=))
 
+(cl-defmethod slack-message-user-ids ((this slack-message))
+  (let ((result))
+    (push (slack-message-sender-id this) result)
+    (cl-loop for r in (slack-message-reactions this)
+             do (cl-loop for u in (oref r users)
+                         do (push u result)))
+    result))
+
 (provide 'slack-message)
 ;;; slack-message.el ends here

--- a/slack-pinned-items-buffer.el
+++ b/slack-pinned-items-buffer.el
@@ -76,25 +76,15 @@
     buf))
 
 (defun slack-create-pinned-items-buffer (room team items)
-  (cl-labels
-      ((create-item
-        (item)
-        (let ((type (plist-get item :type)))
-          (slack-pinned-item-create
-           (cond
-            ((string= type "message")
-             (slack-message-create (plist-get item :message)
-                                   team room))
-            ((string= type "file")
-             (or (slack-file-find (plist-get (plist-get item :file) :id) team)
-                 (slack-file-create (plist-get item :file)))))))))
-    (slack-if-let* ((buf (slack-buffer-find 'slack-pinned-items-buffer room team)))
-        (progn
-          (oset buf items (mapcar #'create-item items))
-          buf)
-      (slack-pinned-items-buffer :room room
-                                 :team team
-                                 :items (mapcar #'create-item items)))))
+  (slack-if-let* ((buf (slack-buffer-find 'slack-pinned-items-buffer
+                                          room
+                                          team)))
+      (progn
+        (oset buf items items)
+        buf)
+    (slack-pinned-items-buffer :room room
+                               :team team
+                               :items items)))
 
 (cl-defmethod slack-buffer--replace ((this slack-pinned-items-buffer) ts)
   (with-slots (items) this

--- a/slack-room.el
+++ b/slack-room.el
@@ -41,7 +41,6 @@
 (defvar slack-display-team-name)
 (defvar slack-current-buffer)
 (defvar slack-buffer-create-on-notify)
-(defconst slack-room-pins-list-url "https://slack.com/api/pins.list")
 (defconst slack-users-counts-url "https://slack.com/api/users.counts")
 
 (defclass slack-room ()

--- a/slack-room.el
+++ b/slack-room.el
@@ -68,6 +68,8 @@
 
 (cl-defmethod slack-merge ((this slack-room) other)
   "except MESSAGES"
+  (oset this members (oref other members))
+  (oset this members-loaded-p (oref other members-loaded-p))
   (oset this name (oref other name))
   (oset this id (oref other id))
   (oset this created (oref other created))

--- a/slack-search.el
+++ b/slack-search.el
@@ -210,20 +210,28 @@
 (cl-defmethod slack-search-request ((this slack-search-result)
                                     after-success team &optional (page 1))
   (cl-labels
-      ((on-success (&key data &allow-other-keys)
-                   (slack-request-handle-error
-                    (data "slack-search-request")
-                    (let ((search-result
-                           (if (slack-file-search-result-p this)
-                               (slack-search-create-file-result data
-                                                                (oref this sort)
-                                                                (oref this sort-dir))
-                             (slack-search-create-result data
-                                                         (oref this sort)
-                                                         (oref this sort-dir)
-                                                         team))))
-                      (slack-merge this search-result)
-                      (funcall after-success)))))
+      ((callback ()
+                 (funcall after-success))
+       (on-success
+        (&key data &allow-other-keys)
+        (slack-request-handle-error
+         (data "slack-search-request")
+         (let* ((search-result (if (slack-file-search-result-p this)
+                                   (slack-search-create-file-result data
+                                                                    (oref this sort)
+                                                                    (oref this sort-dir))
+                                 (slack-search-create-result data
+                                                             (oref this sort)
+                                                             (oref this sort-dir)
+                                                             team)))
+                (user-ids (slack-team-missing-user-ids
+                           team (cl-loop for match in (oref search-result matches)
+                                         nconc (slack-message-user-ids match)))))
+           (slack-merge this search-result)
+           (if (< 0 (length user-ids))
+               (slack-users-info-request
+                user-ids team :after-success #'(lambda () (callback)))
+             (callback))))))
     (with-slots (query sort sort-dir) this
       (if (< 0 (length query))
           (slack-request
@@ -236,6 +244,10 @@
                           (cons "sort_dir" sort-dir)
                           (cons "page" (number-to-string page)))
             :success #'on-success))))))
+
+(cl-defmethod slack-message-user-ids ((this slack-search-message))
+  (with-slots (message) this
+    (slack-message-user-ids message)))
 
 
 (provide 'slack-search)

--- a/slack-slash-commands.el
+++ b/slack-slash-commands.el
@@ -59,9 +59,6 @@
         (cons command
               (mapconcat #'identity (cdr tokens) " "))))))
 
-(defun slack-slash-commands-join (team _args)
-  (slack-channel-join team t))
-
 (defun slack-command-create (command)
   (cl-labels
       ((slack-core-command-create

--- a/slack-team.el
+++ b/slack-team.el
@@ -339,5 +339,11 @@ you can change current-team with `slack-change-current-team'"
 (cl-defmethod slack-team-token ((this slack-team))
   (oref this token))
 
+(cl-defmethod slack-team-missing-user-ids ((this slack-team) user-ids)
+  (let ((exists-user-ids (mapcar #'(lambda (e) (plist-get e :id))
+                                 (oref this users))))
+    (cl-remove-if #'(lambda (e) (cl-find e exists-user-ids :test #'string=))
+                  (cl-remove-duplicates user-ids :test #'string=))))
+
 (provide 'slack-team)
 ;;; slack-team.el ends here

--- a/slack-thread.el
+++ b/slack-thread.el
@@ -283,7 +283,7 @@ Any other non-nil value: send to the room."
 
 (cl-defmethod slack-message-user-ids ((this slack-thread))
   (with-slots (messages root) this
-    (nconc (mapcan #'slack-message-user-ids
+    (nconc (cl-mapcan #'slack-message-user-ids
                    messages)
            (slack-message-user-ids root))))
 

--- a/slack-user.el
+++ b/slack-user.el
@@ -234,16 +234,16 @@
                                            (cl-find (plist-get u :id)
                                                     ids
                                                     :test #'string=))
-                                       (oref team users))))
-             (if (< 0 (length queue))
-                 (progn
-                   (slack-log (format "Fetching users... [%s/%s]"
-                                      (* batch-size (- iter-count (length queue)))
-                                      (length user-ids))
-                              team :level 'info)
-                   (request (pop queue)))
-               (when (functionp after-success)
-                 (funcall after-success))))))
+                                       (oref team users))))))
+          (if (< 0 (length queue))
+              (progn
+                (slack-log (format "Fetching users... [%s/%s]"
+                                   (* batch-size (- iter-count (length queue)))
+                                   (length user-ids))
+                           team :level 'info)
+                (request (pop queue)))
+            (when (functionp after-success)
+              (funcall after-success))))
          (request (user-ids)
                   (slack-request
                    (slack-request-create
@@ -268,9 +268,9 @@
                    (cons user
                          (cl-remove-if #'(lambda (user)
                                            (string= (plist-get user :id) user-id))
-                                       (oref team users))))
-             (when (functionp after-success)
-               (funcall after-success))))))
+                                       (oref team users))))))
+          (when (functionp after-success)
+            (funcall after-success))))
       (slack-request
        (slack-request-create
         slack-user-info-url

--- a/slack-user.el
+++ b/slack-user.el
@@ -67,6 +67,11 @@
           (plist-get user :real_name)
         (plist-get user :name))))
 
+(defun slack-user--name (user team)
+  (if (oref team full-and-display-names)
+      (plist-get user :real_name)
+    (plist-get user :name)))
+
 (defun slack-user-status (id team)
   "Find user by ID in TEAM, then return user's status in string."
   (let* ((user (slack-user--find id team))

--- a/slack-user.el
+++ b/slack-user.el
@@ -131,20 +131,48 @@
                                            (cons "status_emoji" emoji)))))
       :success #'on-success))))
 
-(defun slack-bot-info-request (bot_id team &optional after-success)
+(defun slack-bot-info-request (bot-id team &optional after-success)
   (cl-labels
       ((on-success (&key data &allow-other-keys)
                    (slack-request-handle-error
                     (data "slack-bot-info-request")
-                    (push (plist-get data :bot) (oref team bots))
-                    (if after-success
-                        (funcall after-success team)))))
+                    (let ((bot (plist-get data :bot)))
+                      (oset team bots
+                            (cons bot
+                                  (cl-remove-if #'(lambda (bot)
+                                                    (string= (plist-get bot :id) bot-id))
+                                                (oref team bots))))))
+                   (if after-success
+                       (funcall after-success))))
     (slack-request
      (slack-request-create
       slack-bot-info-url
       team
-      :params (list (cons "bot" bot_id))
+      :params (list (cons "bot" bot-id))
       :success #'on-success))))
+
+(defun slack-bots-info-request (bot-ids team &optional after-success)
+  (cl-labels
+      ((success (&key data &allow-other-keys)
+                (slack-request-handle-error
+                 (data "slack-bots-info-request")
+                 (let* ((bots (plist-get data :bots))
+                        (ids (mapcar #'(lambda (e) (plist-get e :id)) bots)))
+                   (oset team bots (append bots
+                                           (cl-remove-if
+                                            #'(lambda (u)
+                                                (cl-find (plist-get u :id)
+                                                         ids
+                                                         :test #'string=))
+                                            (oref team bots))))))
+                (if after-success
+                    (funcall after-success))))
+    (slack-request
+     (slack-request-create
+      slack-bot-info-url
+      team
+      :params (list (cons "bots" (mapconcat #'identity bot-ids ",")))
+      :success #'success))))
 
 (defface slack-user-profile-header-face
   '((t (:foreground "#FFA000"
@@ -209,74 +237,88 @@
 (defun slack--user-select (team)
   (slack-select-from-list ((slack-user-names team) "Select User: ")))
 
-(cl-defun slack-users-info-request (user-ids team &key after-success)
-  (let* ((batch-size 400)
-         (iter-count (ceiling (/ (length user-ids) (float batch-size))))
-         (queue nil))
-    (cl-loop for i from 0 to (1- iter-count)
-             do (push (cl-subseq user-ids
-                                 (* i batch-size)
-                                 (min (+ (* i batch-size) batch-size)
-                                      (length user-ids)))
-                      queue))
-    (setq queue (reverse queue))
-    (cl-labels
-        ((on-success
-          (&key data &allow-other-keys)
-          (slack-request-handle-error
-           (data "slack-users-info-request")
-           (let* ((users (plist-get data :users))
-                  (ids (mapcar #'(lambda (e) (plist-get e :id))
-                               users)))
-             (oset team users (append users
-                                      (cl-remove-if
-                                       #'(lambda (u)
-                                           (cl-find (plist-get u :id)
-                                                    ids
-                                                    :test #'string=))
-                                       (oref team users))))))
-          (if (< 0 (length queue))
-              (progn
-                (slack-log (format "Fetching users... [%s/%s]"
-                                   (* batch-size (- iter-count (length queue)))
-                                   (length user-ids))
-                           team :level 'info)
-                (request (pop queue)))
-            (when (functionp after-success)
-              (funcall after-success))))
-         (request (user-ids)
-                  (slack-request
-                   (slack-request-create
-                    slack-user-info-url
-                    team
-                    :params (list (cons "users"
-                                        (mapconcat #'identity user-ids ",")))
-                    :success #'on-success))))
-      (request (pop queue)))))
+(cl-defun slack-users-info-request (user--ids team &key after-success)
+  (let ((bot-ids nil)
+        (user-ids nil))
+    (cl-loop for id in user--ids
+             do (if (string-prefix-p "B" id)
+                    (push id bot-ids)
+                  (push id user-ids)))
+    (if bot-ids
+        (slack-bots-info-request bot-ids
+                                 team
+                                 #'(lambda () (slack-users-info-request user-ids
+                                                                        team
+                                                                        :after-success after-success)))
+      (let* ((batch-size 400)
+             (iter-count (ceiling (/ (length user-ids) (float batch-size))))
+             (queue nil))
+        (cl-loop for i from 0 to (1- iter-count)
+                 do (push (cl-subseq user-ids
+                                     (* i batch-size)
+                                     (min (+ (* i batch-size) batch-size)
+                                          (length user-ids)))
+                          queue))
+        (setq queue (reverse queue))
+        (cl-labels
+            ((on-success
+              (&key data &allow-other-keys)
+              (slack-request-handle-error
+               (data "slack-users-info-request")
+               (let* ((users (plist-get data :users))
+                      (ids (mapcar #'(lambda (e) (plist-get e :id))
+                                   users)))
+                 (oset team users (append users
+                                          (cl-remove-if
+                                           #'(lambda (u)
+                                               (cl-find (plist-get u :id)
+                                                        ids
+                                                        :test #'string=))
+                                           (oref team users))))))
+              (if (< 0 (length queue))
+                  (progn
+                    (slack-log (format "Fetching users... [%s/%s]"
+                                       (* batch-size (- iter-count (length queue)))
+                                       (length user-ids))
+                               team :level 'info)
+                    (request (pop queue)))
+                (when (functionp after-success)
+                  (funcall after-success))))
+             (request (user-ids)
+                      (slack-request
+                       (slack-request-create
+                        slack-user-info-url
+                        team
+                        :params (list (cons "users"
+                                            (mapconcat #'identity user-ids ",")))
+                        :success #'on-success))))
+          (request (pop queue)))))))
 
 (cl-defun slack-user-info-request (user-id team &key after-success)
   (if (listp user-id)
       (slack-users-info-request user-id team
                                 :after-success after-success)
-    (cl-labels
-        ((on-success
-          (&key data &allow-other-keys)
-          (slack-request-handle-error
-           (data "slack-user-info-request")
-           (let ((user (plist-get data :user)))
-             (oset team users
-                   (cons user
-                         (cl-remove-if #'(lambda (user)
-                                           (string= (plist-get user :id) user-id))
-                                       (oref team users))))))
-          (when (functionp after-success)
-            (funcall after-success))))
-      (slack-request
-       (slack-request-create
-        slack-user-info-url
-        team
-        :params (list (cons "user" user-id))
-        :success #'on-success)))))
+    (if (string-prefix-p "B" user-id)
+        (slack-bot-info-request user-id team after-success)
+      (cl-labels
+          ((on-success
+            (&key data &allow-other-keys)
+            (slack-request-handle-error
+             (data "slack-user-info-request")
+             (let ((user (plist-get data :user)))
+               (oset team users
+                     (cons user
+                           (cl-remove-if #'(lambda (user)
+                                             (string= (plist-get user :id) user-id))
+                                         (oref team users))))))
+            (when (functionp after-success)
+              (funcall after-success))))
+        (slack-request
+         (slack-request-create
+          slack-user-info-url
+          team
+          :params (list (cons "user" user-id))
+          :success #'on-success))))))
 
 (defun slack-user-image-url-24 (user)
   (plist-get (slack-user-profile user) :image_24))

--- a/slack-util.el
+++ b/slack-util.el
@@ -32,6 +32,7 @@
 
 (defvar slack-completing-read-function)
 (defvar slack-buffer-function)
+(defvar slack-next-page-token "[Next page]")
 
 (defalias 'slack-if-let*
   (if (fboundp 'if-let*)

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -223,7 +223,7 @@
                                   (slack-ws-reconnect ws team))
               (on-open ()
                        (slack-conversations-list-update team)
-                       (slack-user-list-update team)
+                       ;; (slack-user-list-update team)
                        (cl-loop for buffer in (oref team slack-message-buffer)
                                 do (slack-if-let*
                                        ((live-p (buffer-live-p buffer))

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -569,7 +569,7 @@ TEAM is one of `slack-teams'"
         (slack-message-update message team)
       (slack-bot-info-request bot-id
                               team
-                              #'(lambda (team)
+                              #'(lambda ()
                                   (slack-message-update message team))))))
 
 (defun slack-ws-payload-pong-p (payload)

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -456,7 +456,7 @@ TEAM is one of `slack-teams'"
 (defun slack-ws-handle-team-join (payload team)
   (let ((user (slack-decode (plist-get payload :user))))
     (cl-labels
-        ((after-success (_data)
+        ((after-success ()
                         (let ((user-id (plist-get user :id)))
                           (slack-log (format "User %s Joind Team: %s"
                                              (slack-user-name user-id team)

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -543,8 +543,19 @@ TEAM is one of `slack-teams'"
   (let ((subtype (plist-get payload :subtype)))
     (if (string= subtype "bot_message")
         (slack-ws-update-bot-message payload team)
-      (slack-message-update (slack-message-create payload team)
-                            team))))
+      (let ((message (slack-message-create payload team)))
+        (slack-if-let* ((user (slack-user-find message team)))
+            (slack-message-update message team)
+          (progn
+            (slack-log (format "User not found: %S"
+                               (slack-message-sender-id message))
+                       team :level 'debug)
+            (slack-user-info-request
+             (slack-message-sender-id message)
+             team
+             :after-success
+             #'(lambda ()
+                 (slack-message-update message team)))))))))
 
 (defun slack-ws-update-bot-message (payload team)
   (let* ((bot-id (plist-get payload :bot_id))

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -456,7 +456,7 @@ TEAM is one of `slack-teams'"
 (defun slack-ws-handle-team-join (payload team)
   (let ((user (slack-decode (plist-get payload :user))))
     (cl-labels
-        ((after-success (data)
+        ((after-success (_data)
                         (let ((user-id (plist-get user :id)))
                           (slack-log (format "User %s Joind Team: %s"
                                              (slack-user-name user-id team)

--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -789,27 +789,15 @@ TEAM is one of `slack-teams'"
 (defun slack-ws-handle-member-joined-channel (payload team)
   (slack-if-let* ((user (plist-get payload :user))
                   (channel (slack-room-find (plist-get payload :channel) team)))
-      (progn
-        (cl-pushnew user (oref channel members)
-                    :test #'string=)
-        (slack-log (format "%s joined %s"
-                           (slack-user-name user team)
-                           (slack-room-name channel team))
-                   team
-                   :level 'info))))
+      (cl-pushnew user (oref channel members)
+                  :test #'string=)))
 
 (defun slack-ws-handle-member-left_channel (payload team)
   (slack-if-let* ((user (plist-get payload :user))
                   (channel (slack-room-find (plist-get payload :channel) team)))
-      (progn
-        (oset channel members
-              (cl-remove-if #'(lambda (e) (string= e user))
-                            (oref channel members)))
-        (slack-log (format "%s left %s"
-                           (slack-user-name user team)
-                           (slack-room-name channel team))
-                   team
-                   :level 'info))))
+      (oset channel members
+            (cl-remove-if #'(lambda (e) (string= e user))
+                          (oref channel members)))))
 
 (defun slack-ws-handle-dnd-updated (payload team)
   (let* ((user (slack-user--find (plist-get payload :user) team))


### PR DESCRIPTION
instead of retrieve all users in workspace, call `users.info` with user ids

- [x] conversations.history
- [x] message event
- [x] thread replies
- [x] stars 
- [x] search
- [x] files
- [x] All Threads
- [x] Pins
- [x] typing

close #383 
close #388 