### PR TITLE
Limit users query params

### DIFF
--- a/slack-buffer.el
+++ b/slack-buffer.el
@@ -195,7 +195,9 @@
   (slack-if-let* ((buffer slack-current-buffer)
                   (reaction (get-text-property (point) 'reaction))
                   (team (oref buffer team)))
-      (message (slack-reaction-help-text reaction team))))
+      (slack-reaction-help-text reaction
+                                team
+                                #'(lambda (text) (message text)))))
 
 (defun slack-buffer-subscribe-cursor-event (window prev-point type)
   (slack-if-let* ((buffer slack-current-buffer))

--- a/slack-message-reaction.el
+++ b/slack-message-reaction.el
@@ -66,10 +66,9 @@
         (slack-if-let* ((reaction (ignore-errors
                                     (get-text-property (point)
                                                        'reaction))))
-            (let ((user-names (slack-reaction-user-names reaction
-                                                         team)))
-              (message "reacted users: %s"
-                       (mapconcat #'identity user-names ", ")))
+            (slack-reaction-help-text reaction
+                                      team
+                                      #'(lambda (message) (message message)))
           (message "Can't get reaction:")))))
 
 (defun slack-message-reaction-select (reactions)
@@ -83,7 +82,8 @@
 
 (defun slack-message-reaction-input ()
   (let ((reaction (slack-select-emoji)))
-    (if (and (string-prefix-p ":" reaction)
+    (if (and (string-prefix-p(mapcar #'(lambda (user) (slack-user--name user team))
+                                     users) ":" reaction)
              (string-suffix-p ":" reaction))
         (substring reaction 1 -1)
       reaction)))

--- a/slack-message.el
+++ b/slack-message.el
@@ -353,9 +353,6 @@
               (when user-id
                 (push user-id result)))
             (setq start (match-end 0))))))
-    (cl-loop for r in (slack-message-reactions this)
-             do (cl-loop for u in (oref r users)
-                         do (push u result)))
     result))
 
 (provide 'slack-message)

--- a/slack-user.el
+++ b/slack-user.el
@@ -267,7 +267,7 @@
                                  #'(lambda () (slack-user-info-request user-ids
                                                                        team
                                                                        :after-success after-success)))
-      (let* ((batch-size 400)
+      (let* ((batch-size 30)
              (iter-count (ceiling (/ (length user-ids) (float batch-size))))
              (queue nil))
         (cl-loop for i from 0 to (1- iter-count)

--- a/slack-user.el
+++ b/slack-user.el
@@ -73,9 +73,7 @@
 (defun slack-user-name (id team)
   "Find user by ID in TEAM, then return user's name."
   (slack-if-let* ((user (slack-user--find id team)))
-      (if (oref team full-and-display-names)
-          (plist-get user :real_name)
-        (plist-get user :name))))
+      (slack-user--name user team)))
 
 (defun slack-user--name (user team)
   (if (oref team full-and-display-names)


### PR DESCRIPTION
close #393 
- slack limited `users` to 30 query in some account.
- remove reacted users from prefetch
- fetch reacted users when display
