### PR TITLE
Fix: curl: (1) Protocol 'http not supported or disabled in libcurl

### DIFF
--- a/slack-request.el
+++ b/slack-request.el
@@ -361,10 +361,10 @@
            (header (or (and token
                             need-token-p
                             (string-prefix-p "https" url)
-                            (format "-H 'Authorization: Bearer %s'" token))
+                            (format "-H \"Authorization: Bearer %s\"" token))
                        ""))
-           (output (format "--output '%s'" name))
-           (command (format "curl --silent --show-error --fail --location %s %s '%s'" output header url))
+           (output (format "--output \"%s\"" name))
+           (command (format "curl --silent --show-error --fail --location %s %s \"%s\"" output header url))
            (proc (start-process-shell-command "slack-curl-downloader"
                                               "slack-curl-downloader"
                                               command)))


### PR DESCRIPTION
When running emacs-slack on Windows with curl backend lots of these errors are present:

curl: (1) Protocol 'http not supported or disabled in libcurl

Changing the single quotes to escaped double quotes as Windows doesn't handle
single quotes in arguments very well.

See:
https://stackoverflow.com/questions/6884669/curl-1-protocol-https-not-supported-or-disabled-in-libcurl