### PR TITLE
Check whether to download emoji before trying to complete on them

### DIFF
--- a/slack-emoji.el
+++ b/slack-emoji.el
@@ -86,7 +86,8 @@
 
 (defun slack-select-emoji ()
   (if (fboundp 'emojify-completing-read)
-      (emojify-completing-read "Select Emoji: ")
+      (progn (emojify-download-emoji-maybe)
+             (emojify-completing-read "Select Emoji: "))
     (read-from-minibuffer "Emoji: ")))
 
 (provide 'slack-emoji)


### PR DESCRIPTION
Doing `slack-user-set-status` gives `Command attempted to use
minibuffer while in minibuffer` if you've never used emojify
before. It seems it's because emojify wants to ask me whether I should
download emojis, but we're already using the minibuffer for
completing-read.