### PR TITLE
Empty string as default in slack-select-multiple

### DIFF
--- a/slack-util.el
+++ b/slack-util.el
@@ -150,9 +150,13 @@
                              (list
                               (funcall prompt-fn loop-count)
                               (if result (cons "" collection) collection)
-                              nil t
+                              nil       ; predicate
+                              t         ; require-match
                               (when (functionp initial-input-fn)
-                                (funcall initial-input-fn loop-count))))))
+                                (funcall initial-input-fn loop-count))
+                              nil       ; history
+                              ""        ; def
+                              ))))
         (if (and selected (< 0 (length selected)))
             (progn
               (push (cdr (cl-assoc selected collection :test #'equal))


### PR DESCRIPTION
I have `(setq slack-completing-read-function #'ivy-completing-read)`

I tried `slack-file-upload` and selected file and room – then it asks for

    "Select another channel (or leave empty): "

but since it's configured to require a match, I can't leave it empty.

Users could work around this with

`(setq slack-completing-read-function
   #'ivy-completing-read-with-empty-string-def)`

but then you get that completion function for *all* slack completion,
which we don't want. So instead, use an empty string def in
`slack-select-multiple`.