### PR TITLE
Visible threads

### DIFF
--- a/slack-bot.el
+++ b/slack-bot.el
@@ -26,23 +26,34 @@
 
 (require 'slack-team)
 
+(defun slack-bot-append (bots team)
+  (oset team
+        bots
+        (append (cl-remove-if #'(lambda (bot)
+                                  (cl-find-if #'(lambda (e)
+                                                  (string= (plist-get e :id)
+                                                           (plist-get bot :id)))
+                                              bots))
+                              (oref team bots))
+                bots)))
+
 (defun slack-find-bot (id team)
   (with-slots (users bots) team
-    (or (cl-find-if #'(lambda (user)
-                        (string= id (plist-get user :bot_id)))
-                    users)
-        (cl-find-if #'(lambda (bot)
+    (or (cl-find-if #'(lambda (bot)
                         (string= id (plist-get bot :id)))
-                    bots))))
+                    bots)
+        (cl-find-if #'(lambda (user)
+                        (string= id (plist-get user :bot_id)))
+                    users))))
 
 (defun slack-find-bot-by-name (name team)
   (with-slots (bots users) team
-    (or (cl-find-if #'(lambda (user)
-                        (string= name (plist-get user :name)))
-                    users)
-        (cl-find-if #'(lambda (bot)
+    (or (cl-find-if #'(lambda (bot)
                         (string= name (plist-get bot :name)))
-                    bots))))
+                    bots)
+        (cl-find-if #'(lambda (user)
+                        (string= name (plist-get user :name)))
+                    users))))
 
 
 

--- a/slack-channel.el
+++ b/slack-channel.el
@@ -69,10 +69,6 @@
                                     channels)
                   (when (functionp after-success)
                     (funcall after-success team))
-                  (mapc #'(lambda (room)
-                            (slack-request-worker-push
-                             (slack-conversations-info-request room team)))
-                        (oref team channels))
                   (slack-log "Slack Channel List Updated"
                              team :level 'info)))
       (slack-conversations-list team #'success (list "public_channel")))))

--- a/slack-conversations.el
+++ b/slack-conversations.el
@@ -540,8 +540,12 @@
       ((success (&key data &allow-other-keys)
                 (slack-request-handle-error
                  (data "slack-conversations-view")
-                 (let* ((new-room (slack-room-create
-                                   (plist-get data :channel)
+                 (let* ((key (cl-case (eieio-object-class-name room)
+                               (slack-channel :channel)
+                               (slack-im :im)
+                               (slack-group :group)))
+                        (new-room (slack-room-create
+                                   (plist-get data key)
                                    (eieio-object-class-name room)))
                         (bots (plist-get data :bots))
                         (users (plist-get data :users))

--- a/slack-conversations.el
+++ b/slack-conversations.el
@@ -328,12 +328,6 @@
                                     groups)
                   (slack-merge-list (oref team ims)
                                     ims)
-                  (cl-loop for room in (append (oref team channels)
-                                               (oref team groups)
-                                               (oref team ims))
-                           do (slack-request-worker-push
-                               (slack-conversations-info-request
-                                room team)))
                   (slack-counts-update team)
                   (slack-user-info-request
                    (mapcar #'(lambda (im) (oref im user))

--- a/slack-group.el
+++ b/slack-group.el
@@ -80,10 +80,6 @@
                                     groups)
                   (when (functionp after-success)
                     (funcall after-success team))
-                  (mapc #'(lambda (room)
-                            (slack-request-worker-push
-                             (slack-conversations-info-request room team)))
-                        (oref team groups))
                   (slack-log "Slack Group List Updated"
                              team :level 'info)))
       (slack-conversations-list team #'success (list "private_channel" "mpim")))))

--- a/slack-im.el
+++ b/slack-im.el
@@ -106,10 +106,6 @@
                                     ims)
                   (when (functionp after-success)
                     (funcall after-success team))
-                  (mapc #'(lambda (room)
-                            (slack-request-worker-push
-                             (slack-conversations-info-request room team)))
-                        (oref team ims))
                   (slack-log "Slack Im List Updated"
                              team :level 'info)
                   (slack-team-send-presence-sub team)))

--- a/slack-message-buffer.el
+++ b/slack-message-buffer.el
@@ -286,10 +286,10 @@
 
       (cl-labels
           ((paginate (cursor)
-                     (slack-conversations-history room team
-                                                  :oldest latest
-                                                  :cursor cursor
-                                                  :after-success #'after-success))
+                     (slack-conversations-view room team
+                                               :oldest latest
+                                               :cursor cursor
+                                               :after-success #'after-success))
            (after-success (messages next-cursor)
                           (slack-room-append-messages room messages team)
                           (if (and next-cursor (< 0 (length next-cursor)))
@@ -303,9 +303,9 @@
                                (slack-buffer-insert-messages this messages)
                                (slack-buffer-goto (slack-buffer-last-read this))
                                (slack-buffer-update-marker-overlay this)))))
-        (slack-conversations-history room team
-                                     :oldest latest
-                                     :after-success #'after-success)))))
+        (slack-conversations-view room team
+                                  :oldest latest
+                                  :after-success #'after-success)))))
 
 (cl-defmethod slack-buffer-load-more ((this slack-message-buffer))
   (with-slots (room team oldest) this
@@ -345,9 +345,9 @@
                           (oset this cursor next-cursor)
                           (slack-room-prepend-messages room messages team)
                           (update-buffer (slack-room-sorted-messages room))))
-        (slack-conversations-history room team
-                                     :cursor (oref this cursor)
-                                     :after-success #'after-success)))))
+        (slack-conversations-view room team
+                                  :cursor (oref this cursor)
+                                  :after-success #'after-success)))))
 
 (cl-defmethod slack-buffer-display-pins-list ((this slack-message-buffer))
   (with-slots (room team) this
@@ -642,7 +642,7 @@
                                   team)))
       (if buf (open buf)
         (message "No Message in %s, fetching from server..." (slack-room-name room team))
-        (slack-conversations-history
+        (slack-conversations-view
          room team
          :after-success #'(lambda (messages cursor)
                             (slack-room-set-messages room messages team)
@@ -652,7 +652,7 @@
   (slack-if-let* ((buffer (slack-buffer-find 'slack-message-buffer this team)))
       (slack-buffer-update buffer message :replace replace)
     (and slack-buffer-create-on-notify
-         (slack-conversations-history
+         (slack-conversations-view
           this team
           :after-success #'(lambda (messages cursor)
                              (slack-room-set-messages this messages team)

--- a/slack-message-buffer.el
+++ b/slack-message-buffer.el
@@ -852,7 +852,7 @@
               (let ((thread (make-instance 'slack-thread
                                            :thread_ts thread-ts)))
                 (slack-thread-show-messages thread room team)))
-          (slack-buffer-start-thread this ts))))))
+          (slack-buffer-start-thread this message ts))))))
 
 (cl-defmethod slack-buffer-start-thread ((this slack-message-buffer) message ts)
   (when (slack-reply-broadcast-message-p message)

--- a/slack-message-formatter.el
+++ b/slack-message-formatter.el
@@ -124,6 +124,11 @@ see \"Formatting dates\" section in https://api.slack.com/docs/message-formattin
   :type '(repeat (cons symbol string))
   :group 'slack)
 
+(defcustom slack-visible-thread-sign ":left_speech_bubble: "
+  "Used to thread message sign if visible-threads mode."
+  :type 'string
+  :group 'slack)
+
 (defun slack-message-put-header-property (header)
   (if header
       (propertize header 'face 'slack-message-output-header)))
@@ -235,10 +240,18 @@ see \"Formatting dates\" section in https://api.slack.com/docs/message-formattin
   (with-slots (text) m
     (let ((body (slack-message-unescape-string text team)))
       (when body
-        (propertize body 'slack-text-type 'mrkdwn)))))
+        (format "%s%s"
+                (if (and (slack-team-visible-threads-p team)
+                         (oref m thread-ts))
+                    slack-visible-thread-sign
+                  "")
+                (propertize body 'slack-text-type 'mrkdwn))))))
 
 (cl-defmethod slack-message-body ((m slack-reply-broadcast-message) team)
-  (format "Replied to a thread: \n%s"
+  (format "%s%s"
+          (if (slack-team-visible-threads-p team)
+              slack-visible-thread-sign
+            "Replied to a thread: \n")
           (let ((body (slack-message-unescape-string (oref m text) team)))
             (when body
               (propertize body 'slack-text-type 'mrkdwn)))))

--- a/slack-message.el
+++ b/slack-message.el
@@ -365,5 +365,11 @@
             (setq start (match-end 0))))))
     result))
 
+(cl-defmethod slack-message-visible-p ((this slack-message) team)
+  (if (slack-team-visible-threads-p team)
+      t
+    (or (not (slack-thread-message-p this))
+        (slack-reply-broadcast-message-p this))))
+
 (provide 'slack-message)
 ;;; slack-message.el ends here

--- a/slack-message.el
+++ b/slack-message.el
@@ -65,6 +65,12 @@
    (thread :initarg :thread :initform nil)
    (thread-ts :initarg :thread_ts :initform nil)
    (hide :initarg :hide :initform nil)
+   ;; TODO remove slack-thread
+   ;; (reply-count :initarg :reply_count :initform 0 :type number)
+   ;; (reply-users-count :initarg :reply_users_count :initform 0 :type number)
+   ;; (reply-users :initarg :reply_users :initform '())
+   ;; (replies :initarg :replies :initform '())
+   ;; (subscribed :initarg :subscribed :initform nil :type boolean)
    (files :initarg :files :initform '())
    (edited :initarg :edited :initform nil)
    (is-ephemeral :initarg :is_ephemeral :initform nil)

--- a/slack-team.el
+++ b/slack-team.el
@@ -189,11 +189,29 @@ use `slack-change-current-team' to change `slack-current-team'"
 
 ;;;###autoload
 (defun slack-register-team (&rest plist)
-  "PLIST must contain :name :client-id :client-secret with value.
-setting :token will reduce your configuration step.
-you will notified when receive message with channel included in subscribed-channels.
-if :default is t and `slack-prefer-current-team' is t, skip selecting team when channels listed.
-you can change current-team with `slack-change-current-team'"
+  "PLIST must contain :name and either :client-id and :client-secret or :token.
+Available options (property name, type, default value)
+:subscribed-channels [ list symbol ] '()
+  notified when new message arrived in these channels.
+:default [boolean] nil
+  if `slack-prefer-current-team' is t,
+  some functions use this team without asking.
+:display-profile-image [boolean] nil
+:full-and-display-names [boolean] nil
+  if t, use full name to display user name.
+:mark-as-read-immediately [boolean] these
+  if t, mark messages as read when open channel.
+  if nil, mark messages as read when cursor hovered.
+:modeline-enabled [boolean] nil
+  if t, display mention count and has unread in modeline.
+:modeline-name [or nil string] nil
+  use this value in modeline.
+  if nil, use team name.
+:visible-threads [boolean] nil
+  if t, thread replies are also displayed in channel buffer.
+:websocket-event-log-enabled [boolean] nil
+  if t, websocket event is logged.
+  use `slack-log-open-event-buffer' to open the buffer."
   (interactive
    (let ((name (read-from-minibuffer "Team Name: "))
          (client-id (read-from-minibuffer "Client Id: "))

--- a/slack-team.el
+++ b/slack-team.el
@@ -120,6 +120,7 @@ use `slack-change-current-team' to change `slack-current-team'"
    (files :initform '() :type list)
    (counts :initform nil)
    (emoji-master :initform (make-hash-table :test 'equal))
+   (visible-threads :initarg :visible-threads :initform nil :type boolean)
    ))
 
 (defun slack-create-team (plist)
@@ -371,6 +372,9 @@ you can change current-team with `slack-change-current-team'"
                              (list :id (oref this message-id)
                                    :type type
                                    :ids ids))))
+
+(cl-defmethod slack-team-visible-threads-p ((this slack-team))
+  (oref this visible-threads))
 
 (provide 'slack-team)
 ;;; slack-team.el ends here

--- a/slack-user.el
+++ b/slack-user.el
@@ -274,6 +274,17 @@
 (defun slack--user-select (team)
   (slack-select-from-list ((slack-user-names team) "Select User: ")))
 
+(defun slack-user-append (users team)
+  (oset team
+        users
+        (append (cl-remove-if #'(lambda (user)
+                                  (cl-find-if #'(lambda (e)
+                                                  (string= (plist-get e :id)
+                                                           (plist-get user :id)))
+                                              users))
+                              (oref team users))
+                users)))
+
 (cl-defun slack-users-info-request (user--ids team &key after-success)
   (let ((bot-ids nil)
         (user-ids nil))


### PR DESCRIPTION
close #418 

- add `visible-thread` to options
- add `slack-vislble-thread-sign` 

```emacs-lisp
(slack-register-team
   :default nil
   :name "emacs-slack"
   ;; snip
   :visible-threads t
   )
```

```emacs-lisp
(defcustom slack-visible-thread-sign ":left_speech_bubble: "
  "Used to thread message sign if visible-threads mode."
  :type 'string
  :group 'slack)
```