### PR TITLE
Fix 453

### DIFF
--- a/slack-im.el
+++ b/slack-im.el
@@ -114,13 +114,13 @@
 (defun slack-im-close ()
   "Close direct message."
   (interactive)
-  (let* ((team (slack-team-select))
-         (im (slack-current-room-or-select
-              #'(lambda ()
-                  (cl-remove-if #'(lambda (im-names)
-                                    (not (oref (cdr im-names) is-open)))
-                                (slack-im-names team))))))
-    (slack-conversations-close im team)))
+  (slack-if-let-room-and-team (room team)
+      (slack-conversations-close room team)
+    (let* ((team (slack-team-select))
+           (im (slack-select-from-list
+                   ((slack-im-names team)
+                    "Select Channel: "))))
+      (slack-conversations-close im team))))
 
 (defun slack-im-open ()
   (interactive)

--- a/slack-room.el
+++ b/slack-room.el
@@ -239,17 +239,6 @@
                       (cons "ts"  ts))
         :success #'on-update-mark)))))
 
-(defun slack-current-room-or-select (room-alist-func &optional select)
-  (if (and (not select)
-           (bound-and-true-p slack-current-buffer)
-           (slot-boundp slack-current-buffer 'room))
-      (slack-buffer-room slack-current-buffer)
-    (let* ((room-alist (if (functionp room-alist-func)
-                           (funcall room-alist-func)
-                         room-alist-func)))
-      (slack-select-from-list
-          (room-alist "Select Channel: ")))))
-
 (cl-defmethod slack-room-member-p ((_room slack-room)) t)
 
 (cl-defmethod slack-room-archived-p ((_room slack-room)) nil)

--- a/slack-util.el
+++ b/slack-util.el
@@ -65,6 +65,23 @@
             (value (pop ,dup)))
        ,@body)))
 
+(defun slack-current-room-and-team ()
+  (if (and (bound-and-true-p slack-current-buffer)
+           (slot-exists-p slack-current-buffer 'room-id)
+           (slot-boundp slack-current-buffer 'room-id)
+           (slot-exists-p slack-current-buffer 'team)
+           (slot-boundp slack-current-buffer 'team))
+      (list (slack-buffer-room slack-current-buffer)
+            (oref slack-current-buffer team))
+    (list nil nil)))
+
+(defmacro slack-if-let-room-and-team (var-list then &rest else)
+  (declare (indent 2) (debug t))
+  `(destructuring-bind ,var-list (slack-current-room-and-team)
+     (if (and ,@var-list)
+         ,then
+       ,@else)))
+
 (defun slack-seq-to-list (seq)
   (if (listp seq) seq (append seq nil)))
 


### PR DESCRIPTION
close #453 
`room` is not defined in slack-current-buffer.
And fixes when current room’s team is different from default team. 