### PR TITLE
Add Expanding the File Path to Aid Mac Users Using `curl`.

### DIFF
--- a/slack-file.el
+++ b/slack-file.el
@@ -436,7 +436,8 @@
        (team (oref buffer team))
        (file (car (find-file-read-args "Select File: " t)))
        (filename (read-from-minibuffer "Filename: "
-                                       (file-name-nondirectory file)))
+                                       (expand-file-name
+                                        (file-name-nondirectory file))))
        (filetype (slack-file-select-filetype (file-name-extension file)))
        (initial-comment (read-from-minibuffer "Message: ")))
       (cl-labels

--- a/slack-file.el
+++ b/slack-file.el
@@ -434,10 +434,9 @@
   (slack-if-let*
       ((buffer slack-current-buffer)
        (team (oref buffer team))
-       (file (car (find-file-read-args "Select File: " t)))
+       (file (expand-file-name (car (find-file-read-args "Select File: " t))))
        (filename (read-from-minibuffer "Filename: "
-                                       (expand-file-name
-                                        (file-name-nondirectory file))))
+                                       (file-name-nondirectory file)))
        (filetype (slack-file-select-filetype (file-name-extension file)))
        (initial-comment (read-from-minibuffer "Message: ")))
       (cl-labels


### PR DESCRIPTION
I don't know if this'll solve all instances of potential problems but, per @umairbinaltaf and my own experiences, at least part of the issue that's run into by Mac users is the file not being expanded (e.g. `~` instead of `/Users/<user>/`) which causes the file upload to fail.

Expanding the file path has fixed every issue I've run into so suggesting this as, at the very least, a partial fix for #477.