### PR TITLE
make reconnect-count-max configurable

### DIFF
--- a/slack-team-ws.el
+++ b/slack-team-ws.el
@@ -39,7 +39,7 @@
    (reconnect-timer :initform nil)
    (reconnect-after-sec :initform 10)
    (reconnect-count :initform 0)
-   (reconnect-count-max :initform 360)
+   (reconnect-count-max :initarg :reconnect-auto :initform 360)
    (last-pong :initform nil)
    (waiting-send :initform nil)
    (ping-check-timers :initform (make-hash-table :test 'equal))

--- a/slack-team-ws.el
+++ b/slack-team-ws.el
@@ -39,7 +39,7 @@
    (reconnect-timer :initform nil)
    (reconnect-after-sec :initform 10)
    (reconnect-count :initform 0)
-   (reconnect-count-max :initarg :reconnect-auto :initform 360)
+   (reconnect-count-max :initarg :reconnect-count-max :initform 360)
    (last-pong :initform nil)
    (waiting-send :initform nil)
    (ping-check-timers :initform (make-hash-table :test 'equal))


### PR DESCRIPTION
This limits the hang when emacs-slack tries to, unsuccessfully, reconnect.