### PR TITLE
reduce default reconnect-count-max

### DIFF
--- a/slack-team-ws.el
+++ b/slack-team-ws.el
@@ -39,7 +39,7 @@
    (reconnect-timer :initform nil)
    (reconnect-after-sec :initform 10)
    (reconnect-count :initform 0)
-   (reconnect-count-max :initform 360)
+   (reconnect-count-max :initform 3)
    (last-pong :initform nil)
    (waiting-send :initform nil)
    (ping-check-timers :initform (make-hash-table :test 'equal))


### PR DESCRIPTION
Reconnecting requires resources and it is useless when there is no
internet.

The current behavior is even worse when you are connected (by
mistake)n on a network with a captive portal. Emacs will try to
connect to slack 360 times, every time the certificate check will
fail (because the captive portal intercepts it), the user then a scary
prompt requesting it to validate the invalid certificate and there's
no way to stop Emacs.

This commit reduces the default to a much more reasonable value:
3. That means that Emacs will try to reconnect for 30s, if it doesn't
work it will give up. The user can always `slack-start` again.