### PR TITLE
remove potential shell escape attack surface from curl downloader

### DIFF
--- a/slack-request.el
+++ b/slack-request.el
@@ -395,16 +395,18 @@
     (let* ((url-obj (url-generic-parse-url url))
            (need-token-p (and url-obj
                               (string-match-p "slack" (url-host url-obj))))
-           (header (or (and token
-                            need-token-p
-                            (string-prefix-p "https" url)
-                            (format "-H \"Authorization: Bearer %s\"" token))
-                       ""))
-           (output (format "--output \"%s\"" name))
-           (command (format "curl --silent --show-error --fail --location %s %s \"%s\"" output header url))
-           (proc (start-process-shell-command "slack-curl-downloader"
-                                              "slack-curl-downloader"
-                                              command)))
+           (proc (apply #'start-process
+                        "slack-curl-downloader"
+                        "slack-curl-downloader"
+                        (executable-find "curl")
+                        "--silent"
+                        "--show-error"
+                        "--fail"
+                        "--location"
+                        "--output" name
+                        "--url" url
+                        (when (and token need-token-p (string-prefix-p "https" url))
+                          `("-H" ,(format "Authorization: Bearer %s" token))))))
       (set-process-sentinel proc #'sentinel))))
 
 (provide 'slack-request)


### PR DESCRIPTION
Download file url and name are slack server-side controlled, thus there exists some potential for a malicious (or insufficiently filtering) slack server to provide potentially non-sanitized input to the curl download routines. By moving from start-process-shell-command to start-process for asynchronous curl downloads we reduce remote attack surface and limit the potential for shell escape and command injection vulnerabilities.