### PR TITLE
add tracking to thread buffers

### DIFF
--- a/slack-message-buffer.el
+++ b/slack-message-buffer.el
@@ -870,6 +870,7 @@
     (let ((buf (slack-create-thread-message-buffer (slack-buffer-room this)
                                                    team
                                                    ts)))
+      (tracking-add-buffer (slack-buffer-buffer buf))
       (slack-buffer-display buf))))
 
 (cl-defmethod slack-thread-show-messages ((this slack-message) room team)
@@ -877,6 +878,7 @@
       ((after-success (_next-cursor has-more)
                       (let ((buf (slack-create-thread-message-buffer
                                   room team (slack-thread-ts this) has-more)))
+                        (tracking-add-buffer (slack-buffer-buffer buf))
                         (slack-buffer-display buf))))
     (slack-thread-replies this room team
                           :after-success #'after-success)))


### PR DESCRIPTION
Fixes https://github.com/yuya373/emacs-slack/issues/396, in theory.

@yuya373 I tried to follow your advice [here](https://github.com/yuya373/emacs-slack/compare/master...matthew-piziak:track-threads?expand=1). 

**Questions:**
Am I using `slack-buffer-buffer` correctly here?
How can I spoof an incoming thread message, to test tracking?

Thanks in advance!
