### PR TITLE
Customizable faces for tracking mode-line notifications

### DIFF
--- a/slack-message-buffer.el
+++ b/slack-message-buffer.el
@@ -39,6 +39,7 @@
 (require 'slack-user-profile-buffer)
 (require 'slack-mrkdwn)
 (require 'slack-modeline)
+(require 'slack-message-notification)
 
 (defvar slack-completing-read-function)
 (defvar slack-channel-button-keymap
@@ -663,7 +664,8 @@
                              (slack-room-set-messages this messages team)
                              (tracking-add-buffer
                               (slack-buffer-buffer
-                               (slack-create-message-buffer this cursor team))))))))
+                               (slack-create-message-buffer this cursor team))
+                              (slack-messages-tracking-faces messages this team)))))))
 
 (defun slack-select-unread-rooms ()
   (interactive)
@@ -745,7 +747,8 @@
          (cl-labels ((after-success (_next-cursor has-more)
                                     (tracking-add-buffer (slack-buffer-buffer
                                                           (slack-create-thread-message-buffer
-                                                           room team (slack-thread-ts message) has-more)))))
+                                                           room team (slack-thread-ts message) has-more))
+                                                         slack-message-tracking-faces)))
            (slack-thread-replies message room team
                                  :after-success #'after-success)))))
 

--- a/slack-message-notification.el
+++ b/slack-message-notification.el
@@ -62,6 +62,11 @@
   :type '(choice file (const :tag "Stock alert icon" nil))
   :group 'slack)
 
+(defcustom slack-message-tracking-faces nil
+  "A list of faces to be added by `tracking` to the mode-line notifications."
+  :type '(repeat face)
+  :group 'slack)
+
 (defun slack-message-notify (message room team)
   (if slack-message-custom-notifier
       (funcall slack-message-custom-notifier message room team)
@@ -88,6 +93,13 @@
            (slack-room-subscribedp room team)
            (slack-message-mentioned-p message team)
            (slack-message-subscribed-thread-message-p message room))))
+
+(defun slack-messages-tracking-faces (messages room team)
+  (when (and slack-message-tracking-faces
+             (cl-find-if (lambda (m)
+                           (ignore-errors (slack-message-notify-p m room team)))
+                         messages))
+    slack-message-tracking-faces))
 
 (defun slack-message-notify-alert (message room team)
   (if (slack-message-notify-p message room team)


### PR DESCRIPTION
The tracking library accepts the specification of one or more faces to
use in its mode-line notifications.  This commit adds the ability to
tell slack to include user-defined faces when using the tracking
library.

I'm not sure if i've put the customize definition in the right module,
but it's very easy to move around.