### PR TITLE
add (helm "3.0") to Package-Requires

### DIFF
--- a/slack.el
+++ b/slack.el
@@ -6,7 +6,7 @@
 ;; Author: yuya.minami <yuya.minami@yuyaminami-no-MacBook-Pro.local>
 ;; Keywords: tools
 ;; Version: 0.0.2
-;; Package-Requires: ((websocket "1.8") (request "0.2.0") (circe "2.3") (alert "1.2") (emojify "0.4") (emacs "24.4"))
+;; Package-Requires: ((websocket "1.8") (request "0.2.0") (circe "2.3") (alert "1.2") (emojify "0.4") (helm "3.0") (emacs "24.4"))
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or


### PR DESCRIPTION
Fix #499

It's not clear what version of `helm` is actually required, but since `helm-slack.el` was introduced in September 2018 and `helm` version 3.0 was released in August 2018, this seems like a reasonable choice.

Note that 99% of all the downloads of helm are from MELPA which continuously builds the latest commit from github (not MELPA stable which contains the version tagged releases). So it's likely many users are using versions of helm newer than 3.0 depending when they last updated their packages.