### PR TITLE
support the `:display-profile-image` argument in `register-team`

### DIFF
--- a/slack-message.el
+++ b/slack-message.el
@@ -200,10 +200,11 @@
          (status (slack-message-user-status this team))
          (edited-at (slack-format-ts (slack-message-edited-at this)))
          (deleted-at (slack-format-ts (oref this deleted-at))))
-    (concat (slack-if-let* ((image (slack-message-profile-image this team)))
-                (concat (propertize "image" 'display image 'face 'slack-profile-image-face)
-                        " ")
-              "")
+    (concat (if (oref team display-profile-image)
+                (slack-if-let* ((image (slack-message-profile-image this team)))
+                    (concat (propertize "image" 'display image 'face 'slack-profile-image-face)
+                            " ")
+                  ""))
             (slack-message-put-header-property (concat name
                                                        (if (slack-string-blankp status)
                                                            ""

--- a/slack-team.el
+++ b/slack-team.el
@@ -95,6 +95,7 @@ use `slack-change-current-team' to change `slack-current-team'"
    (slack-room-info-buffer :initform nil :type (or null hash-table))
    (slack-all-threads-buffer :initform nil :type (or null hash-table))
    (full-and-display-names :initarg :full-and-display-names :initform nil)
+   (display-profile-image :initarg :display-profile-image :initform t)
    (mark-as-read-immediately :initarg :mark-as-read-immediately :initform t)
    (commands :initform '() :type list)
    (usergroups :initarg :usergroups :initform '() :type list)

--- a/slack.el
+++ b/slack.el
@@ -173,7 +173,8 @@ Available options (property name, type, default value)
 :default [boolean] nil
   if `slack-prefer-current-team' is t,
   some functions use this team without asking.
-:display-profile-image [boolean] nil
+:display-profile-image [boolean] t
+  if t, display profile image next to names
 :full-and-display-names [boolean] nil
   if t, use full name to display user name.
 :mark-as-read-immediately [boolean] these


### PR DESCRIPTION
I noticed that `:display-profile-image` wasn't supported. Was that unintentional? If so, here is a PR to enable it. I've tested it locally and it seems to work for me.