### PR TITLE
Fix display text from slack-message-embed-channel

### DIFF
--- a/slack-message-sender.el
+++ b/slack-message-sender.el
@@ -125,7 +125,7 @@
       (slack-select-from-list
           ((slack-channel-names team) "Select Channel: ")
           (slack-insert-channel-mention (oref selected id)
-                                        (format "@%s" (slack-room-name selected team))))))
+                                        (format "#%s" (slack-room-name selected team))))))
 
 (defun slack-insert-channel-mention (channel-id display)
   (insert (slack-propertize-mention-text 'slack-message-mention-face


### PR DESCRIPTION
It previously showed @channel instead of #channel.

I tested by eval'ing the function and trying it once.  I saw that the resulting message displayed correctly and that clicking the mention jumped me to the right channel, both in emacs slack and on the Android client.  Let me know if you'd like more testing.