### PR TITLE
emoji: take into account change in  `emojify-completing-read`

### DIFF
--- a/slack-emoji.el
+++ b/slack-emoji.el
@@ -97,11 +97,11 @@
              (cl-labels
                  ((select ()
                           (emojify-completing-read "Select Emoji: "
-                                                   #'(lambda (_emoji data)
-                                                       (or (gethash (gethash "emoji" data)
+                                                   #'(lambda (data)
+                                                       (or (gethash data
                                                                     slack-emoji-master
                                                                     nil)
-                                                           (gethash (gethash "emoji" data)
+                                                           (gethash data
                                                                     (oref team emoji-master)
                                                                     nil))))))
                (if (< 0 (hash-table-count slack-emoji-master))
@@ -119,9 +119,13 @@
                           do (let ((short-names (plist-get emoji :short_names)))
                                (when short-names
                                  (cl-loop for name in short-names
-                                          do (puthash (format ":%s:" name)
-                                                      t
-                                                      slack-emoji-master))))))))
+                                          do (let* ((emoji-key (format ":%s:" name))
+                                                    (emoji (emojify-get-emoji emoji-key))
+                                                    (emoji-name (if emoji (ht-get emoji "name") ""))
+                                                    (emoji-style (if emoji (ht-get emoji "style") "")))
+                                               (puthash (format "%s - %s (%s)" emoji-key emoji-name emoji-style)
+                                                        t
+                                                        slack-emoji-master)))))))))
     (slack-request
      (slack-request-create
       slack-emoji-master-data-url


### PR DESCRIPTION
`emojify-completing-read` used to take as input a predicate that takes
two arguments as input.

We seem to take the second argument containing something like
`:flag-yt:` and we used it to look at `slack-emoji-master` to see if
the emoji exists.

Now I takes a single argument which looks like:

`":flag-yt: - Mayotte (github)`

This does not match the contents of the cache anymore.

In this patch, I propose changing the format of the cache, to match
the cache created by `emojify`, and then changing the lambda passed to
`emojify-completing-read` to make take into account the new format of
the list.

This patch is not complete yet, as we need to make sure `(oref team
emoji-master)` is built with the same format.