### PR TITLE
Remove predicate for emojify new data format

### DIFF
--- a/slack-emoji.el
+++ b/slack-emoji.el
@@ -96,14 +96,7 @@
       (progn (emojify-download-emoji-maybe)
              (cl-labels
                  ((select ()
-                          (emojify-completing-read "Select Emoji: "
-                                                   #'(lambda (_emoji data)
-                                                       (or (gethash (gethash "emoji" data)
-                                                                    slack-emoji-master
-                                                                    nil)
-                                                           (gethash (gethash "emoji" data)
-                                                                    (oref team emoji-master)
-                                                                    nil))))))
+                          (emojify-completing-read "Select Emoji: ")))
                (if (< 0 (hash-table-count slack-emoji-master))
                    (select)
                  (slack-emoji-fetch-master-data (car (hash-table-values slack-teams-by-token)))


### PR DESCRIPTION
Emojify has changed its data format. This predicate lambda is not compatible.

Since this emojify [commit](https://github.com/iqbalansari/emacs-emojify/commit/f082f0759e491d5e2fdaaf9fff4e0b0d4a9fa417#diff-07702ecb10fa4bc8b54cde88474f4fcaR804), data format has been changed from ht to a list.

Removing this predicate works fine for users since now the filtering task has been forwarded to completion frameworks like ivy or helm. Tested in spacemacs using ivy.

Feel free to make any modification as you see fit.