### PR TITLE
Slack already sends info about image without height width and bytes

### DIFF
--- a/slack-block.el
+++ b/slack-block.el
@@ -707,9 +707,9 @@
   ((type :initarg :type :type string :initform "image")
    (image-url :initarg :image_url :type string)
    (alt-text :initarg :alt_text :type string)
-   (image-height :initarg :image_height :type number)
-   (image-width :initarg :image_width :type number)
-   (image-bytes :initarg :image_bytes :type number)))
+   (image-height :initarg :image_height :type (or number null))
+   (image-width :initarg :image_width :type (or number null))
+   (image-bytes :initarg :image_bytes :type (or number null))))
 
 (defun slack-create-image-block-element (payload)
   (make-instance 'slack-image-block-element


### PR DESCRIPTION
we should make optional fields (image_height, image_width and image_bytes) in slack-image-block-element 
because slack doesn't send it. I checked and with this change channels are properly read but I'm using emacs in terminal only so I couldn't check if images are loaded properly.